### PR TITLE
Database: previously accessed columns cache is bound with stack trace

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -598,8 +598,11 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 		if ($this->generalCacheKey) {
 			return $this->generalCacheKey;
 		}
-
-		return $this->generalCacheKey = md5(serialize(array(__CLASS__, $this->name, $this->sqlBuilder->getConditions())));
+		$key = array(__CLASS__, $this->name, $this->sqlBuilder->getConditions());
+		foreach (debug_backtrace(PHP_VERSION_ID >= 50306 ? DEBUG_BACKTRACE_IGNORE_ARGS : FALSE) as $item) {
+			$key[] = isset($item['file'], $item['line']) ? $item['file'] . $item['line'] : NULL;
+		};
+		return $this->generalCacheKey = md5(serialize($key));
 	}
 
 


### PR DESCRIPTION
Moved from https://github.com/nette/nette/pull/1136
