### PR TITLE
PgSqlDriver reflection fixes

### DIFF
--- a/tests/Database/Reflection.postgre.phpt
+++ b/tests/Database/Reflection.postgre.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Same table names reflection across the schemas
+ * Test: PostgreSQL specific reflection
  * @dataProvider? databases.ini  postgresql
  */
 
@@ -12,19 +12,19 @@ require __DIR__ . '/connect.inc.php'; // create $connection
 Nette\Database\Helpers::loadFromFile($connection, Tester\FileMock::create('
 	DROP SCHEMA IF EXISTS "one" CASCADE;
 	DROP SCHEMA IF EXISTS "two" CASCADE;
-	
+
 	CREATE SCHEMA "one";
 	CREATE SCHEMA "two";
-	
+
 	CREATE TABLE "one"."master" ("one_id" integer NOT NULL, PRIMARY KEY ("one_id"));
 	CREATE TABLE "two"."master" ("two_id" integer NOT NULL, PRIMARY KEY ("two_id"));
-	
+
 	ALTER INDEX "one"."master_pkey" RENAME TO "one_master_pkey";
 	ALTER INDEX "two"."master_pkey" RENAME TO "two_master_pkey";
-	
+
 	CREATE TABLE "one"."slave" ("one_id" integer NULL);
 	CREATE TABLE "two"."slave" ("two_id" integer NULL);
-	
+
 	ALTER TABLE "one"."slave" ADD CONSTRAINT "one_slave_fk" FOREIGN KEY ("one_id") REFERENCES "one"."master"("one_id");
 	ALTER TABLE "two"."slave" ADD CONSTRAINT "two_slave_fk" FOREIGN KEY ("two_id") REFERENCES "two"."master"("two_id");
 '));
@@ -36,6 +36,7 @@ function filter($columns) {
 }
 
 
+// Reflection for tables with the same name but different schema
 $connection->query('SET search_path TO one, two');
 Assert::same(array('master', 'slave'), filter($driver->getTables()));
 Assert::same(array('one_id'), filter($driver->getColumns('master')));
@@ -47,6 +48,13 @@ Assert::same(array('master', 'slave'), filter($driver->getTables()));
 Assert::same(array('two_id'), filter($driver->getColumns('master')));
 Assert::same(array('two_master_pkey'), filter($driver->getIndexes('master')));
 Assert::same(array('two_slave_fk'), filter($driver->getForeignKeys('slave')));
+
+
+// Reflection for FQN
+Assert::same(array('one_id'), filter($driver->getColumns('one.master')));
+Assert::same(array('one_master_pkey'), filter($driver->getIndexes('one.master')));
+Assert::same(array('one_slave_fk'), filter($driver->getForeignKeys('one.slave')));
+
 
 // Limit foreign keys for current schemas only
 $connection->query('ALTER TABLE "one"."slave" ADD CONSTRAINT "one_two_fk" FOREIGN KEY ("one_id") REFERENCES "two"."master"("two_id")');


### PR DESCRIPTION
The main reason for PR is #17. Possible BC issue is when you pass an undefined table name for reflection. Current behaviour is silent empty result, new behaviour is e.g. `PDOException: SQLSTATE[42P01]: Undefined table: 7 ERROR:  relation "undefined" does not exist`. The same for wrong table name case-sensitivity.

Second commit changes foreign key definitions loading. You got all FKs from all schemas in current implementation. New implementation returns only table from `search_path` schemas.

Third commit allows reflection for table written in FQN (with schema).
