### PR TITLE
Row creation done by row factory (not hard-wired)

### DIFF
--- a/src/Bridges/DatabaseDI/DatabaseExtension.php
+++ b/src/Bridges/DatabaseDI/DatabaseExtension.php
@@ -78,6 +78,9 @@ class DatabaseExtension extends Nette\DI\CompilerExtension
 				->setClass('Nette\Database\Structure')
 				->setArguments(array($connection));
 
+			$rowFactory = $container->addDefinition($prefix . $this->prefix("$name.rowFactory"))
+				->setClass('Nette\Database\Table\RowFactory');
+
 			if (!empty($info['reflection'])) {
 				$conventionsServiceName = 'reflection';
 				$info['conventions'] = $info['reflection'];
@@ -105,7 +108,7 @@ class DatabaseExtension extends Nette\DI\CompilerExtension
 			}
 
 			$container->addDefinition($prefix . $this->prefix("$name.context"))
-				->setClass('Nette\Database\Context', array($connection, $structure, $conventions))
+				->setClass('Nette\Database\Context', array($connection, $structure, $rowFactory, $conventions))
 				->setAutowired($info['autowired']);
 
 			if ($container->parameters['debugMode'] && $info['debugger']) {

--- a/src/Database/Context.php
+++ b/src/Database/Context.php
@@ -8,6 +8,7 @@
 namespace Nette\Database;
 
 use Nette,
+	Nette\Database\Table\IRowFactory,
 	Nette\Database\Conventions\StaticConventions;
 
 
@@ -24,6 +25,9 @@ class Context extends Nette\Object
 	/** @var IStructure */
 	private $structure;
 
+	/** @var IRowFactory */
+	private $rowFactory;
+
 	/** @var IConventions */
 	private $conventions;
 
@@ -34,10 +38,11 @@ class Context extends Nette\Object
 	private $preprocessor;
 
 
-	public function __construct(Connection $connection, IStructure $structure, IConventions $conventions = NULL, Nette\Caching\IStorage $cacheStorage = NULL)
+	public function __construct(Connection $connection, IStructure $structure, IRowFactory $rowFactory, IConventions $conventions = NULL, Nette\Caching\IStorage $cacheStorage = NULL)
 	{
 		$this->connection = $connection;
 		$this->structure = $structure;
+		$this->rowFactory = $rowFactory;
 		$this->conventions = $conventions ?: new StaticConventions;
 		$this->cacheStorage = $cacheStorage;
 	}
@@ -121,7 +126,7 @@ class Context extends Nette\Object
 	 */
 	public function table($table)
 	{
-		return new Table\Selection($this, $this->conventions, $table, $this->cacheStorage);
+		return new Table\Selection($this, $this->conventions, $this->rowFactory, $table, $this->cacheStorage);
 	}
 
 

--- a/src/Database/Table/IRowFactory.php
+++ b/src/Database/Table/IRowFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Database\Table;
+
+interface IRowFactory
+{
+
+	/**
+	 * @return ActiveRow
+	 */
+	public function create($tableName, array $row, Selection $table);
+
+}

--- a/src/Database/Table/RowFactory.php
+++ b/src/Database/Table/RowFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Database\Table;
+
+
+/**
+ * Row factory.
+ */
+class RowFactory implements IRowFactory
+{
+
+	public function create($tableName, array $row, Selection $table)
+	{
+		return new ActiveRow($row, $table);
+	}
+
+}

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -9,7 +9,8 @@ namespace Nette\Database\Table;
 
 use Nette,
 	Nette\Database\Context,
-	Nette\Database\IConventions;
+	Nette\Database\IConventions,
+	Nette\Database\Table\IRowFactory;
 
 
 /**
@@ -28,6 +29,9 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 
 	/** @var IConventions */
 	protected $conventions;
+
+	/** @var IRowFactory */
+	protected $rowFactory;
 
 	/** @var Nette\Caching\Cache */
 	protected $cache;
@@ -91,10 +95,11 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 	 * @param  string  table name
 	 * @param  Nette\Caching\IStorage|NULL
 	 */
-	public function __construct(Context $context, IConventions $conventions, $tableName, Nette\Caching\IStorage $cacheStorage = NULL)
+	public function __construct(Context $context, IConventions $conventions, IRowFactory $rowFactory, $tableName, Nette\Caching\IStorage $cacheStorage = NULL)
 	{
 		$this->context = $context;
 		$this->conventions = $conventions;
+		$this->rowFactory = $rowFactory;
 		$this->name = $tableName;
 
 		$this->cache = $cacheStorage ? new Nette\Caching\Cache($cacheStorage, 'Nette.Database.' . md5($context->getConnection()->getDsn())) : NULL;
@@ -510,7 +515,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 
 	protected function createRow(array $row)
 	{
-		return new ActiveRow($row, $this);
+		return $this->rowFactory->create($this->name, $row, $this);
 	}
 
 


### PR DESCRIPTION
This allows better extensibility of Nette Database as anyone can supply their own IRowFactory implementation. As a result it is easier to write ORMs atop of N\DB without actually cluttering the framework with that functionality.
