### PR TITLE
Added custom exceptions

### DIFF
--- a/src/Database/Context.php
+++ b/src/Database/Context.php
@@ -105,8 +105,7 @@ class Context extends Nette\Object
 
 		try {
 			$result = new ResultSet($this->connection, $statement, $params);
-		} catch (\PDOException $e) {
-			$e->queryString = $statement;
+		} catch (DriverException $e) {
 			$this->connection->onQuery($this->connection, $e);
 			throw $e;
 		}

--- a/src/Database/DriverException.php
+++ b/src/Database/DriverException.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Database;
+
+
+/**
+ * Base class for all errors in the driver or SQL server.
+ */
+class DriverException extends \PDOException
+{
+	/** @var string */
+	public $queryString;
+
+
+	/**
+	 * @returns self
+	 */
+	public static function from(\PDOException $src)
+	{
+		$e = new static($src->message, NULL, $src);
+		if (!$src->errorInfo && preg_match('#SQLSTATE\[(.*?)\] \[(.*?)\] (.*)#A', $src->message, $m)) {
+			$m[2] = (int) $m[2];
+			$e->errorInfo = array_slice($m, 1);
+			$e->code = $m[1];
+		} else {
+			$e->errorInfo = $src->errorInfo;
+			$e->code = $src->code;
+		}
+		return $e;
+	}
+
+
+	/**
+	 * @returns int|string|NULL  Driver-specific error code
+	 */
+	public function getDriverCode()
+	{
+		return isset($this->errorInfo[1]) ? $this->errorInfo[1] : NULL;
+	}
+
+
+	/**
+	 * @returns string|NULL  SQLSTATE error code
+	 */
+	public function getSqlState()
+	{
+		return isset($this->errorInfo[0]) ? $this->errorInfo[0] : NULL;
+	}
+
+
+	/**
+	 * @returns string|NULL  SQL command
+	 */
+	public function getQueryString()
+	{
+		return $this->queryString;
+	}
+
+}

--- a/src/Database/Drivers/MsSqlDriver.php
+++ b/src/Database/Drivers/MsSqlDriver.php
@@ -18,6 +18,11 @@ use Nette;
 class MsSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
 
+	public function convertException(\PDOException $e)
+	{
+		return Nette\Database\DriverException::from($e);
+	}
+
 
 	/********************* SQL ****************d*g**/
 

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -43,6 +43,30 @@ class MySqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 	}
 
 
+	/**
+	 * @return Nette\Database\DriverException
+	 */
+	public function convertException(\PDOException $e)
+	{
+		$code = isset($e->errorInfo[1]) ? $e->errorInfo[1] : NULL;
+		if (in_array($code, array(1216, 1217, 1451, 1452, 1701), TRUE)) {
+			return Nette\Database\ForeignKeyConstraintViolationException::from($e);
+
+		} elseif (in_array($code, array(1062, 1557, 1569, 1586), TRUE)) {
+			return Nette\Database\UniqueConstraintViolationException::from($e);
+
+		} elseif ($code >= 2001 && $code <= 2028) {
+			return Nette\Database\ConnectionException::from($e);
+
+		} elseif (in_array($code, array(1048, 1121, 1138, 1171, 1252, 1263, 1566), TRUE)) {
+			return Nette\Database\NotNullConstraintViolationException::from($e);
+
+		} else {
+			return Nette\Database\DriverException::from($e);
+		}
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/Drivers/OciDriver.php
+++ b/src/Database/Drivers/OciDriver.php
@@ -31,6 +31,24 @@ class OciDriver extends Nette\Object implements Nette\Database\ISupplementalDriv
 	}
 
 
+	public function convertException(\PDOException $e)
+	{
+		$code = isset($e->errorInfo[1]) ? $e->errorInfo[1] : NULL;
+		if (in_array($code, array(1, 2299, 38911), TRUE)) {
+			return Nette\Database\UniqueConstraintViolationException::from($e);
+
+		} elseif (in_array($code, array(1400), TRUE)) {
+			return Nette\Database\NotNullConstraintViolationException::from($e);
+
+		} elseif (in_array($code, array(2266, 2291, 2292), TRUE)) {
+			return Nette\Database\ForeignKeyConstraintViolationException::from($e);
+
+		} else {
+			return Nette\Database\DriverException::from($e);
+		}
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/Drivers/OdbcDriver.php
+++ b/src/Database/Drivers/OdbcDriver.php
@@ -18,6 +18,12 @@ use Nette;
 class OdbcDriver extends Nette\Object implements Nette\Database\ISupplementalDriver
 {
 
+	public function convertException(\PDOException $e)
+	{
+		return Nette\Database\DriverException::from($e);
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/Drivers/PgSqlDriver.php
+++ b/src/Database/Drivers/PgSqlDriver.php
@@ -27,6 +27,30 @@ class PgSqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 	}
 
 
+	public function convertException(\PDOException $e)
+	{
+		$code = isset($e->errorInfo[0]) ? $e->errorInfo[0] : NULL;
+		if ($code === '0A000' && strpos($e->getMessage(), 'truncate') !== FALSE) {
+			return Nette\Database\ForeignKeyConstraintViolationException::from($e);
+
+		} elseif ($code === '23502') {
+			return Nette\Database\NotNullConstraintViolationException::from($e);
+
+		} elseif ($code === '23503') {
+			return Nette\Database\ForeignKeyConstraintViolationException::from($e);
+
+		} elseif ($code === '23505') {
+			return Nette\Database\UniqueConstraintViolationException::from($e);
+
+		} elseif ($code === '08006') {
+			return Nette\Database\ConnectionException::from($e);
+
+		} else {
+			return Nette\Database\DriverException::from($e);
+		}
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/Drivers/SqliteDriver.php
+++ b/src/Database/Drivers/SqliteDriver.php
@@ -31,6 +31,35 @@ class SqliteDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	}
 
 
+	public function convertException(\PDOException $e)
+	{
+		$code = isset($e->errorInfo[1]) ? $e->errorInfo[1] : NULL;
+		$msg = $e->getMessage();
+		if ($code !== 19) {
+			return Nette\Database\DriverException::from($e);
+
+		} elseif (strpos($msg, 'must be unique') !== FALSE
+			|| strpos($msg, 'is not unique') !== FALSE
+			|| strpos($msg, 'UNIQUE constraint failed') !== FALSE
+		) {
+			return Nette\Database\UniqueConstraintViolationException::from($e);
+
+		} elseif (strpos($msg, 'may not be NULL') !== FALSE
+			|| strpos($msg, 'NOT NULL constraint failed') !== FALSE
+		) {
+			return Nette\Database\NotNullConstraintViolationException::from($e);
+
+		} elseif (strpos($msg, 'foreign key constraint failed') !== FALSE
+			|| strpos($msg, 'FOREIGN KEY constraint failed') !== FALSE
+		) {
+			return Nette\Database\ForeignKeyConstraintViolationException::from($e);
+
+		} else {
+			return Nette\Database\ConstraintViolationException::from($e);
+		}
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/Drivers/SqlsrvDriver.php
+++ b/src/Database/Drivers/SqlsrvDriver.php
@@ -28,6 +28,12 @@ class SqlsrvDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	}
 
 
+	public function convertException(\PDOException $e)
+	{
+		return Nette\Database\DriverException::from($e);
+	}
+
+
 	/********************* SQL ****************d*g**/
 
 

--- a/src/Database/ISupplementalDriver.php
+++ b/src/Database/ISupplementalDriver.php
@@ -25,6 +25,11 @@ interface ISupplementalDriver
 		SUPPORT_SCHEMA = 'schema';
 
 	/**
+	 * @return DriverException
+	 */
+	function convertException(\PDOException $e);
+
+	/**
 	 * Delimites identifier for use in a SQL statement.
 	 * @param  string
 	 * @return string

--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -60,12 +60,18 @@ class ResultSet extends Nette\Object implements \Iterator, IRowContainer
 		$this->queryString = $queryString;
 		$this->params = $params;
 
-		if (substr($queryString, 0, 2) === '::') {
-			$connection->getPdo()->{substr($queryString, 2)}();
-		} elseif ($queryString !== NULL) {
-			$this->pdoStatement = $connection->getPdo()->prepare($queryString);
-			$this->pdoStatement->setFetchMode(PDO::FETCH_ASSOC);
-			$this->pdoStatement->execute($params);
+		try {
+			if (substr($queryString, 0, 2) === '::') {
+				$connection->getPdo()->{substr($queryString, 2)}();
+			} elseif ($queryString !== NULL) {
+				$this->pdoStatement = $connection->getPdo()->prepare($queryString);
+				$this->pdoStatement->setFetchMode(PDO::FETCH_ASSOC);
+				$this->pdoStatement->execute($params);
+			}
+		} catch (\PDOException $e) {
+			$e = $this->supplementalDriver->convertException($e);
+			$e->queryString = $queryString;
+			throw $e;
 		}
 		$this->time = microtime(TRUE) - $time;
 	}

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -489,7 +489,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 		try {
 			$result = $this->query($this->getSql());
 
-		} catch (\PDOException $exception) {
+		} catch (DriverException $exception) {
 			if (!$this->sqlBuilder->getSelect() && $this->previousAccessedColumns) {
 				$this->previousAccessedColumns = FALSE;
 				$this->accessedColumns = array();

--- a/src/Database/exceptions.php
+++ b/src/Database/exceptions.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Database;
+
+
+/**
+ * Server connection related errors.
+ */
+class ConnectionException extends DriverException
+{
+}
+
+
+/**
+ * Base class for all constraint violation related exceptions.
+ */
+class ConstraintViolationException extends DriverException
+{
+}
+
+
+/**
+ * Exception for a foreign key constraint violation.
+ */
+class ForeignKeyConstraintViolationException extends ConstraintViolationException
+{
+}
+
+
+/**
+ * Exception for a NOT NULL constraint violation.
+ */
+class NotNullConstraintViolationException extends ConstraintViolationException
+{
+}
+
+
+/**
+ * Exception for a unique constraint violation.
+ */
+class UniqueConstraintViolationException extends ConstraintViolationException
+{
+}

--- a/tests/Database/Connection.exceptions.mysql.phpt
+++ b/tests/Database/Connection.exceptions.mysql.phpt
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection exceptions.
+ * @dataProvider? databases.ini  mysql
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $options
+
+
+$e = Assert::exception(function() use ($options) {
+	$connection = new Nette\Database\Connection($options['dsn'], 'unknown', 'unknown');
+}, 'Nette\Database\ConnectionException', '%a% Access denied for user %a%');
+
+Assert::same(1045, $e->getDriverCode());
+Assert::contains($e->getSqlState(), array('HY000', '28000'));
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($connection) {
+	$connection->rollback();
+}, 'Nette\Database\DriverException', 'There is no active transaction', 0);
+
+Assert::same(NULL, $e->getDriverCode());

--- a/tests/Database/Connection.exceptions.phpt
+++ b/tests/Database/Connection.exceptions.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection exceptions.
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+if (!class_exists('PDO')) {
+	Tester\Environment::skip('Requires PHP extension PDO.');
+}
+
+
+$e = Assert::exception(function() {
+	$connection = new Nette\Database\Connection('unknown');
+}, 'Nette\Database\ConnectionException', 'invalid data source name', 0);
+
+Assert::same(NULL, $e->getDriverCode());
+Assert::same(NULL, $e->getSqlState());

--- a/tests/Database/Connection.exceptions.postgre.phpt
+++ b/tests/Database/Connection.exceptions.postgre.phpt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection exceptions.
+ * @dataProvider? databases.ini  postgresql
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $options
+
+
+$e = Assert::exception(function() use ($options) {
+	$connection = new Nette\Database\Connection($options['dsn'], 'unknown', 'unknown');
+}, 'Nette\Database\ConnectionException', '%a% role "unknown" does not exist', '08006');
+
+Assert::same(7, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($connection) {
+	$connection->rollback();
+}, 'Nette\Database\DriverException', 'There is no active transaction', 0);
+
+Assert::same(NULL, $e->getDriverCode());

--- a/tests/Database/Connection.exceptions.sqlite.phpt
+++ b/tests/Database/Connection.exceptions.sqlite.phpt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Test: Nette\Database\Connection exceptions.
+ * @dataProvider? databases.ini  sqlite
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $options
+
+
+$e = Assert::exception(function() use ($options) {
+	$connection = new Nette\Database\Connection('sqlite:.');
+}, 'Nette\Database\ConnectionException', 'SQLSTATE[HY000] [14] unable to open database file', 'HY000');
+
+Assert::same(14, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($connection) {
+	$connection->rollback();
+}, 'Nette\Database\DriverException', 'There is no active transaction', 0);
+
+Assert::same(NULL, $e->getDriverCode());

--- a/tests/Database/Connection.lazy.phpt
+++ b/tests/Database/Connection.lazy.phpt
@@ -19,7 +19,7 @@ if (!class_exists('PDO')) {
 test(function() { // non lazy
 	Assert::exception(function() {
 		$connection = new Nette\Database\Connection('dsn', 'user', 'password');
-	}, 'PDOException', 'invalid data source name');
+	}, 'Nette\Database\DriverException', 'invalid data source name');
 });
 
 
@@ -28,7 +28,7 @@ test(function() { // lazy
 	$context = new Nette\Database\Context($connection, new Structure($connection, new DevNullStorage()));
 	Assert::exception(function() use ($context) {
 		$context->query('SELECT ?', 10);
-	}, 'PDOException', 'invalid data source name');
+	}, 'Nette\Database\DriverException', 'invalid data source name');
 });
 
 
@@ -36,7 +36,7 @@ test(function() {
 	$connection = new Nette\Database\Connection('dsn', 'user', 'password', array('lazy' => TRUE));
 	Assert::exception(function() use ($connection) {
 		$connection->quote('x');
-	}, 'PDOException', 'invalid data source name');
+	}, 'Nette\Database\DriverException', 'invalid data source name');
 });
 
 

--- a/tests/Database/ResultSet.exceptions.mysql.phpt
+++ b/tests/Database/ResultSet.exceptions.mysql.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Nette\Database\ResultSet & Connection exceptions.
+ * @dataProvider? databases.ini  mysql
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/files/{$driverName}-nette_test1.sql");
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('SELECT');
+}, 'Nette\Database\DriverException', '%a% Syntax error %a%', '42000');
+
+Assert::same(1064, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('INSERT INTO author (id, name, web, born) VALUES (11, "", "", NULL)');
+}, 'Nette\Database\UniqueConstraintViolationException', '%a% Integrity constraint violation: %a%', '23000');
+
+Assert::same(1062, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('INSERT INTO author (name, web, born) VALUES (NULL, "", NULL)');
+}, 'Nette\Database\NotNullConstraintViolationException', '%a% Integrity constraint violation: %a%', '23000');
+
+Assert::same(1048, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('INSERT INTO book (author_id, translator_id, title) VALUES (999, 12, "")');
+}, 'Nette\Database\ForeignKeyConstraintViolationException', '%a% a foreign key constraint fails %a%', '23000');
+
+Assert::same(1452, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());

--- a/tests/Database/ResultSet.exceptions.postgre.phpt
+++ b/tests/Database/ResultSet.exceptions.postgre.phpt
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Test: Nette\Database\ResultSet & Connection exceptions.
+ * @dataProvider? databases.ini  postgresql
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/files/{$driverName}-nette_test1.sql");
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('SELECT');
+}, 'Nette\Database\DriverException', '%a% syntax error %A%', '42601');
+
+Assert::same(7, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query("INSERT INTO author (id, name, web, born) VALUES (11, '', '', NULL)");
+}, 'Nette\Database\UniqueConstraintViolationException', '%a% Unique violation: %A%', '23505');
+
+Assert::same(7, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query("INSERT INTO author (name, web, born) VALUES (NULL, '', NULL)");
+}, 'Nette\Database\NotNullConstraintViolationException', '%a% Not null violation: %A%', '23502');
+
+Assert::same(7, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query("INSERT INTO book (author_id, translator_id, title) VALUES (999, 12, '')");
+}, 'Nette\Database\ForeignKeyConstraintViolationException', '%a% Foreign key violation: %A%', '23503');
+
+Assert::same(7, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());

--- a/tests/Database/ResultSet.exceptions.sqlite.phpt
+++ b/tests/Database/ResultSet.exceptions.sqlite.phpt
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test: Nette\Database\ResultSet & Connection exceptions.
+ * @dataProvider? databases.ini  sqlite
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/files/{$driverName}-nette_test1.sql");
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('SELECT');
+}, 'Nette\Database\DriverException', '%a% syntax error', 'HY000');
+
+Assert::same(1, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('INSERT INTO author (id, name, web, born) VALUES (11, "", "", NULL)');
+}, 'Nette\Database\UniqueConstraintViolationException', '%a% Integrity constraint violation: %a%', '23000');
+
+Assert::same(19, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('INSERT INTO author (name, web, born) VALUES (NULL, "", NULL)');
+}, 'Nette\Database\NotNullConstraintViolationException', '%a% Integrity constraint violation: %a%', '23000');
+
+Assert::same(19, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());
+
+
+$e = Assert::exception(function() use ($context) {
+	$context->query('PRAGMA foreign_keys=true');
+	$context->query('INSERT INTO book (author_id, translator_id, title) VALUES (999, 12, "")');
+}, 'Nette\Database\ForeignKeyConstraintViolationException', '%a% Integrity constraint violation: %a%', '23000');
+
+Assert::same(19, $e->getDriverCode());
+Assert::same($e->getCode(), $e->getSqlState());


### PR DESCRIPTION
Inspired at http://www.doctrine-project.org

Some notes:

- exception names are taken from [Doctrine](http://apigen.juzna.cz/doc/doctrine/dbal/tree.html) (which are probably taken from Oracle/Java)
- I think that fine-granularity is required for "runtime" exceptions (ConstraintViolationException and its descendants), not for "logic" exceptions (syntax errors, table not found, etc)
- the separation between DriverException and ServerException is IMHO not needed. (It can be added in future with no BC break)
- `new PDO` throws bad exceptions in sense that getCode returns driver-specific error code instead of SQLSTATE error code as stated in documentation. (`$errorInfo` is NULL).
- `ISupplementalDriver::convertException` is static to allow handle exceptions occured by `new PDO`. But I think that this is not needed, we can these exceptions convert to ConnectionException (or DriverException?) without driver.