### PR TITLE
GroupedSelection: Rows are refetched after emptyResultSet call [Closes #15]

### DIFF
--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -176,6 +176,14 @@ class GroupedSelection extends Selection
 	}
 
 
+	protected function emptyResultSet($saveCache = TRUE)
+	{
+		parent::emptyResultSet($saveCache);
+
+		$this->refCacheCurrent['data'] = NULL;
+	}
+
+
 	protected function getRefTable(& $refPath)
 	{
 		$refObj = $this->refTable;


### PR DESCRIPTION
This is EXPERIMENTAL hotfix for very annoying Issue #15.

I can't reproduce the bug. It occurs only sometimes after app deploy & cache clean.

Maybe the problem is that `Selection::emptyResultSet` unsets `$rows` property.
It's OK because `Selection::execute` is called before work with the property and when is not set it will be created and it will be an array.

But in some places there are iterations over it and it reproduces an error.
(On another places there is `foreach ((array) $this->rows ...)` and I can't understand Nette\Database so deeply to make more changes in the code.)

I didn't understand why the error is thrown (see #15).
Now I've tried do anything else. In `GroupedSelection` the method `::execute` is overriden.
But it doesn't write `$rows` property itself. Now I see it calls `parent::execute` but it's not called when some cache key is set.

So I think it can be the problem here with GroupedSelection.
1) `Selection::emptyResultSet` sets `$this->rows = NULL`.
2) `GroupedSelection::execute` doesn't call `parent::execute` and `$rows` property is null even after it has been called.
3) Now we are in invalid state on some places (`$rows` property is NULL but we use it in foreach cycles or array access).

What do you think about it?
I muset wait few days or weeks if error will be away or not but as I've said - I can't reproduce the bug intentionally :cry: 