### PR TITLE
Selection::getReferencedTable always reloads when $row[$column] is NULL

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -846,7 +846,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 		$referenced = & $this->refCache['referenced'][$this->getSpecificCacheKey()]["$table.$column"];
 		$selection = & $referenced['selection'];
 		$cacheKeys = & $referenced['cacheKeys'];
-		if ($selection === NULL || !isset($cacheKeys[$checkPrimaryKey])) {
+		if ($selection === NULL || ($checkPrimaryKey !== NULL && !isset($cacheKeys[$checkPrimaryKey]))) {
 			$this->execute();
 			$cacheKeys = array();
 			foreach ($this->rows as $row) {

--- a/tests/Database/Table/Table.ref().phpt
+++ b/tests/Database/Table/Table.ref().phpt
@@ -31,3 +31,20 @@ test(function() use ($context) {
 test(function() use ($context) {
 	Assert::null($context->table('book')->get(2)->ref('author', 'translator_id'));
 });
+
+test(function() use ($context, $connection) {
+	$counter = 0;
+
+	$connection->onQuery[] = function($connection, $result) use (&$counter) {
+		$counter++;
+	};
+
+	$table = $context->table('book');
+
+	$names = array();
+	foreach ($table as $book) {
+		$translator = $book->ref('author', 'translator_id');
+	}
+
+	Assert::equal(2, $counter);
+});


### PR DESCRIPTION
Using structure like in https://github.com/nette/database/blob/master/tests/Database/files/mysql-nette_test1.sql and doing this:

    $table = $context->table('book');
    foreach ($table as $row) {
        $translator = $row->ref('author', 'translator_id');
    }

These queries are performed:

    SELECT * FROM `book`
    SELECT * FROM `author` WHERE (`id` IN (11, 12))
    SELECT * FROM `author` WHERE (`id` IN (11, 12))

i.e. authors are needlessly refetched.

It does this both on master and 2.3.0 (PHP 5.5.9-1ubuntu4.6, MySQL 5.5.41-0ubuntu0.14.04.1).

It all goes down to https://github.com/nette/database/blob/master/src/Database/Table/Selection.php#L849 - the NULL key is never stored, so it is never found and performs a needless fetch.

The solution would be either to remember the NULL key on first fetch, or never fetch on NULL key. Which is better?