### PR TITLE
GroupedSelection: Rows are refetched when cache is invalid [Closes #15]

### DIFF
--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -202,6 +202,11 @@ class GroupedSelection extends Selection
 		if (isset($referencing[$hash]['data'][$this->active])) {
 			$this->data = & $referencing[$hash]['data'][$this->active];
 		}
+
+		// something went wrong with the cache
+		if ($this->rows === NULL && isset($this->refCacheCurrent['data'])) {
+			$this->emptyResultSet();
+		}
 	}
 
 


### PR DESCRIPTION
See #15 

Currently we use something like this patch in projects and it seems fine.

`GroupedSelection::execute` refetches data only when `isset($this->refCacheCurrent['data']) === TRUE` but sometimes this cache is empty and `$this->rows === NULL`
-> I get errors described in #15 

With this patch, it's OK.

I consider this code only as temporary fix. I don't know NDB too much.