### PR TITLE
SqlBuilder: Selection as parameter - all parameters must be added to where

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -273,7 +273,7 @@ class SqlBuilder extends Nette\Object
 					if ($this->driver->isSupported(ISupplementalDriver::SUPPORT_SUBSELECT)) {
 						$arg = NULL;
 						$replace = $match[2][0] . '(' . $clone->getSql() . ')';
-						$this->parameters['where'] = array_merge($this->parameters['where'], $clone->getSqlBuilder()->parameters['where']);
+						$this->parameters['where'] = array_merge($this->parameters['where'], $clone->getSqlBuilder()->getParameters());
 					} else {
 						$arg = array();
 						foreach ($clone as $row) {


### PR DESCRIPTION
Problem is related only for drivers that support subqueries (like postgres).

Without this fix, selection $x with parameter in having can't be used as parameter in where of selection $y.

It end with error becouse selection $x is converted to sql and apended as subquery to where part of $y. As subquery contains complete SQL of $x, all parameters of $x must be added to $y. Actually, only parameters of where are added to $y.