### PR TITLE
Selection: Related prototype depends on specific cache key

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -893,7 +893,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 			list($table, $column) = $hasMany;
 		}
 
-		$prototype = & $this->refCache['referencingPrototype']["$table.$column"];
+		$prototype = & $this->refCache['referencingPrototype'][$this->getSpecificCacheKey()]["$table.$column"];
 		if (!$prototype) {
 			$prototype = $this->createGroupedSelectionInstance($table, $column);
 			$prototype->where("$table.$column", array_keys((array) $this->rows));

--- a/tests/Database/Table/Table.related().caching.phpt
+++ b/tests/Database/Table/Table.related().caching.phpt
@@ -78,3 +78,22 @@ test(function() use ($context) {
 		'Jakub Vrana',
 	), $translators);
 });
+
+
+
+test(function() use ($context) { // cache can't be affected by inner query!
+	$author = $context->table('author')->get(11);
+	$secondBookTagRels = NULL;
+	foreach ($author->related('book')->order('id') as $book) {
+		if (!isset($secondBookTagRels)) {
+			$bookFromAnotherSelection = $author->related('book')->where('id', $book->id)->fetch();
+			$bookFromAnotherSelection->related('book_tag')->fetchPairs('id');
+			$secondBookTagRels = array();
+		} else {
+			foreach ($book->related('book_tag') as $bookTagRel) {
+				$secondBookTagRels[] = $bookTagRel->tag->name;
+			}
+		}
+	}
+	Assert::same(array('JavaScript'), $secondBookTagRels);
+});


### PR DESCRIPTION
Without this patch, query inside cycle can affect result of getting related rows.. See test for example