### PR TITLE
Sqlsrv driver: support for limit and offset on MS SQL server.

### DIFF
--- a/src/Database/Drivers/SqlsrvDriver.php
+++ b/src/Database/Drivers/SqlsrvDriver.php
@@ -18,10 +18,13 @@ class SqlsrvDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	/** @var Nette\Database\Connection */
 	private $connection;
 
+	/** @var string */
+	private $version;
 
 	public function __construct(Nette\Database\Connection $connection, array $options)
 	{
 		$this->connection = $connection;
+		$this->version = $connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
 	}
 
 
@@ -88,15 +91,22 @@ class SqlsrvDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	 */
 	public function applyLimit(& $sql, $limit, $offset)
 	{
-		if ($limit >= 0) {
-			$sql = preg_replace('#^\s*(SELECT(\s+DISTINCT|\s+ALL)?|UPDATE|DELETE)#i', '$0 TOP ' . (int) $limit, $sql, 1, $count);
-			if (!$count) {
-				throw new Nette\InvalidArgumentException('SQL query must begin with SELECT, UPDATE or DELETE command.');
+		if (version_compare($this->version, 11, '<')) { // 11 == SQL Server 2012
+			if ($limit >= 0) {
+				$sql = preg_replace('#^\s*(SELECT(\s+DISTINCT|\s+ALL)?|UPDATE|DELETE)#i', '$0 TOP ' . (int) $limit, $sql, 1, $count);
+				if (!$count) {
+					throw new Nette\InvalidArgumentException('SQL query must begin with SELECT, UPDATE or DELETE command.');
+				}
 			}
-		}
 
-		if ($offset > 0) {
-			throw new Nette\NotSupportedException('Offset is not supported by this database.');
+			if ($offset > 0) {
+				throw new Nette\NotSupportedException('Offset is not supported by this database.');
+			}
+		} else {
+			if ($limit > 0 || $offset >= 0) {
+				$sql .= ' OFFSET ' . (int) $offset . ' ROWS '
+					. 'FETCH NEXT ' . (int) $limit . ' ROWS ONLY';
+			}
 		}
 	}
 


### PR DESCRIPTION
Since MS SQL 2012 there is equivalent to `LIMIT OFFSET` clause in T-SQL.

But it requires to use `ORDER BY` clause in query, see [official docs](https://technet.microsoft.com/en-us/library/gg699618(v=sql.110).aspx)

To consider:
- add default `ORDER BY` instead of exception
- throw `NotSupportedException` when connected to older MSSQL Server version