### PR TITLE
Helpers::dumpSql() should parse named params

### DIFF
--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -107,31 +107,36 @@ class Helpers
 		}, $sql);
 
 		// parameters
-		$sql = preg_replace_callback('#\?#', function () use ($params, $connection) {
-			static $i = 0;
-			if (!isset($params[$i])) {
+		$sql = preg_replace_callback('#\?|\s?(?<meta>&lt;&gt;|&lt;|&gt;|=)\s?(?<param>\:[^\s\)]+)#', function ($matches) use ($params, $connection) {
+			static $i = 0;$meta = null;
+			if (isset($matches['param']) && isset($params[$matches['param']])) {
+				$param = $params[$matches['param']];
+				$meta  = ' ' . $matches['meta'] . ' ';
+			} elseif (isset($params[$i])) {
+				$param = $params[$i++];
+			} else {
 				return '?';
 			}
-			$param = $params[$i++];
+
 			if (is_string($param) && (preg_match('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{10FFFF}]#u', $param) || preg_last_error())) {
-				return '<i title="Length ' . strlen($param) . ' bytes">&lt;binary&gt;</i>';
+				return $meta . '<i title="Length ' . strlen($param) . ' bytes">&lt;binary&gt;</i>';
 
 			} elseif (is_string($param)) {
 				$length = Nette\Utils\Strings::length($param);
 				$truncated = Nette\Utils\Strings::truncate($param, self::$maxLength);
 				$text = htmlspecialchars($connection ? $connection->quote($truncated) : '\'' . $truncated . '\'', ENT_NOQUOTES, 'UTF-8');
-				return '<span title="Length ' . $length . ' characters">' . $text . '</span>';
+				return $meta . '<span title="Length ' . $length . ' characters">' . $text . '</span>';
 
 			} elseif (is_resource($param)) {
 				$type = get_resource_type($param);
 				if ($type === 'stream') {
 					$info = stream_get_meta_data($param);
 				}
-				return '<i' . (isset($info['uri']) ? ' title="' . htmlspecialchars($info['uri'], ENT_NOQUOTES, 'UTF-8') . '"' : NULL)
+				return $meta . '<i' . (isset($info['uri']) ? ' title="' . htmlspecialchars($info['uri'], ENT_NOQUOTES, 'UTF-8') . '"' : NULL)
 					. '>&lt;' . htmlSpecialChars($type, ENT_NOQUOTES, 'UTF-8') . ' resource&gt;</i> ';
 
 			} else {
-				return htmlspecialchars($param, ENT_NOQUOTES, 'UTF-8');
+				return $meta . htmlspecialchars($param, ENT_NOQUOTES, 'UTF-8');
 			}
 		}, $sql);
 

--- a/tests/Database/Helpers.dumpSql.phpt
+++ b/tests/Database/Helpers.dumpSql.phpt
@@ -22,6 +22,21 @@ test(function () use ($connection) { // string check
 "<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name = <span title=\"Length 15 characters\">'Alexej Chruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name = ?', ['Alexej Chruščev'], $connection));
 });
 
+test(function () use ($connection) { // named param
+	Assert::same(
+"<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name = <span title=\"Length 15 characters\">'Alexej Chruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name = :name', [':name' => 'Alexej Chruščev'], $connection));
+});
+
+test(function () use ($connection) { // named param with compare
+	Assert::same(
+"<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name &lt;&gt; <span title=\"Length 15 characters\">'Alexej Chruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name <> :name', [':name' => 'Alexej Chruščev'], $connection));
+});
+
+test(function () use ($connection) { // named param with compare
+	Assert::same(
+"<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name &gt; <span title=\"Length 15 characters\">'Alexej Chruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name > :name', [':name' => 'Alexej Chruščev'], $connection));
+});
+
 test(function () use ($connection) { // string check with \'
 	Assert::same(
 "<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name = <span title=\"Length 16 characters\">'Alexej Ch\'ruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name = ?', ["Alexej Ch'ruščev"], $connection));


### PR DESCRIPTION
In PDO you can bind named params bindValue('something', 1, PDO::TYPE);

So you can use ResultSet like this

```
$query = 'SELECT * FROM table WHERE id = :something';
$params[':something'] = 1;
$resultSet = new ResultSet($connection, $query, $params);
$connection->onQuery($connection, $resultSet);// log binded param query to Tracy
```

Problem is in Nette\Bridges\DatabaseTracy\ConnectionPanel template which invoke Helpers::dumpSql()

This helper does not support named parameters. Tracy result is: 

```
SELECT * FROM table WHERE id = :something
```

Expected

```
SELECT * FROM table WHERE id = 1
```
