### PR TITLE
SqlBuilder: Remove "AS" keyword in JOINs

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -507,7 +507,7 @@ class SqlBuilder extends Nette\Object
 			list($joinTable, $joinAlias, $table, $tableColumn, $joinColumn) = $join;
 
 			$return .=
-				" LEFT JOIN {$joinTable}" . ($joinTable !== $joinAlias ? " AS {$joinAlias}" : '') .
+				" LEFT JOIN {$joinTable}" . ($joinTable !== $joinAlias ? " {$joinAlias}" : '') .
 				" ON {$table}.{$tableColumn} = {$joinAlias}.{$joinColumn}";
 		}
 

--- a/tests/Database/Table/SqlBuilder.addWhere().phpt
+++ b/tests/Database/Table/SqlBuilder.addWhere().phpt
@@ -48,7 +48,7 @@ test(function () use ($context) { // test Selection with parameters as a paramet
 	$schemaSupported = $context->getConnection()->getSupplementalDriver()->isSupported(ISupplementalDriver::SUPPORT_SCHEMA);
 	Assert::equal(reformat([
 		'mysql' => 'SELECT * FROM `book` WHERE (`id` IN (?))',
-		'SELECT * FROM [book] WHERE ([id] IN (SELECT [id] FROM [book] LEFT JOIN ' . ($schemaSupported ? '[public].[book_tag] AS ' : '') . '[book_tag] ON [book].[id] = [book_tag].[book_id] HAVING COUNT([book_tag].[tag_id]) >))',
+		'SELECT * FROM [book] WHERE ([id] IN (SELECT [id] FROM [book] LEFT JOIN ' . ($schemaSupported ? '[public].[book_tag] ' : '') . '[book_tag] ON [book].[id] = [book_tag].[book_id] HAVING COUNT([book_tag].[tag_id]) >))',
 	]), $sqlBuilder->buildSelectQuery());
 	Assert::count(1, $sqlBuilder->getParameters());
 });

--- a/tests/Database/Table/SqlBuilder.parseJoins().phpt
+++ b/tests/Database/Table/SqlBuilder.parseJoins().phpt
@@ -42,17 +42,17 @@ $tables = $connection->getSupplementalDriver()->getTables();
 if (!in_array($tables[0]['name'], ['npriorities', 'ntopics', 'nusers', 'nusers_ntopics', 'nusers_ntopics_alt'], TRUE)) {
 	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
 		Assert::same(
-			'LEFT JOIN public.nUsers_nTopics AS nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
-			'LEFT JOIN public.nTopics AS topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
-			'LEFT JOIN public.nPriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId',
+			'LEFT JOIN public.nUsers_nTopics nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
+			'LEFT JOIN public.nTopics topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
+			'LEFT JOIN public.nPriorities priorit ON topic.nPriorityId = priorit.nPriorityId',
 			trim($join)
 		);
 
 	} else {
 		Assert::same(
-			'LEFT JOIN nUsers_nTopics AS nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
-			'LEFT JOIN nTopics AS topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
-			'LEFT JOIN nPriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId',
+			'LEFT JOIN nUsers_nTopics nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
+			'LEFT JOIN nTopics topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
+			'LEFT JOIN nPriorities priorit ON topic.nPriorityId = priorit.nPriorityId',
 			trim($join)
 		);
 	}
@@ -60,8 +60,8 @@ if (!in_array($tables[0]['name'], ['npriorities', 'ntopics', 'nusers', 'nusers_n
 } else {
 	Assert::same(
 		'LEFT JOIN nusers_ntopics ON nUsers.nUserId = nusers_ntopics.nUserId ' .
-		'LEFT JOIN ntopics AS topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
-		'LEFT JOIN npriorities AS priorit ON topic.nPriorityId = priorit.nPriorityId',
+		'LEFT JOIN ntopics topic ON nusers_ntopics.nTopicId = topic.nTopicId ' .
+		'LEFT JOIN npriorities priorit ON topic.nPriorityId = priorit.nPriorityId',
 		trim($join)
 	);
 }
@@ -97,14 +97,14 @@ Assert::same('WHERE book_ref.translator_id IS NULL AND book_ref_ref.translator_i
 
 if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
 	Assert::same(
-		'LEFT JOIN public.book AS book_ref ON book.id = book_ref.next_volume ' .
-		'LEFT JOIN public.book AS book_ref_ref ON book_ref.id = book_ref_ref.next_volume',
+		'LEFT JOIN public.book book_ref ON book.id = book_ref.next_volume ' .
+		'LEFT JOIN public.book book_ref_ref ON book_ref.id = book_ref_ref.next_volume',
 		trim($join)
 	);
 } else {
 	Assert::same(
-		'LEFT JOIN book AS book_ref ON book.id = book_ref.next_volume ' .
-		'LEFT JOIN book AS book_ref_ref ON book_ref.id = book_ref_ref.next_volume',
+		'LEFT JOIN book book_ref ON book.id = book_ref.next_volume ' .
+		'LEFT JOIN book book_ref_ref ON book_ref.id = book_ref_ref.next_volume',
 		trim($join)
 	);
 }

--- a/tests/Database/Table/Table.backjoin.phpt
+++ b/tests/Database/Table/Table.backjoin.phpt
@@ -39,7 +39,7 @@ test(function () use ($context, $driver) {
 
 	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
 		Assert::same(
-			reformat('SELECT [author].* FROM [author] LEFT JOIN [public].[book] AS [book] ON [author].[id] = [book].[author_id] WHERE ([book].[translator_id] IS NOT NULL) AND ([author].[id] = ?)'),
+			reformat('SELECT [author].* FROM [author] LEFT JOIN [public].[book] [book] ON [author].[id] = [book].[author_id] WHERE ([book].[translator_id] IS NOT NULL) AND ([author].[id] = ?)'),
 			$authorsSelection->getSql()
 		);
 	} else {

--- a/tests/Database/Table/Table.join.phpt
+++ b/tests/Database/Table/Table.join.phpt
@@ -34,7 +34,7 @@ test(function () use ($context, $driver) {
 
 	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
 		Assert::same(
-			reformat('SELECT [tag].* FROM [book_tag] LEFT JOIN [public].[tag] AS [tag] ON [book_tag].[tag_id] = [tag].[id] WHERE ([book_id] = ?)'),
+			reformat('SELECT [tag].* FROM [book_tag] LEFT JOIN [public].[tag] [tag] ON [book_tag].[tag_id] = [tag].[id] WHERE ([book_id] = ?)'),
 			$joinSql
 		);
 	} else {
@@ -51,12 +51,12 @@ test(function () use ($context, $driver) {
 
 	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
 		Assert::same(
-			reformat('SELECT [Tag].[id] FROM [book_tag] LEFT JOIN [public].[tag] AS [Tag] ON [book_tag].[tag_id] = [Tag].[id] WHERE ([book_id] = ?)'),
+			reformat('SELECT [Tag].[id] FROM [book_tag] LEFT JOIN [public].[tag] [Tag] ON [book_tag].[tag_id] = [Tag].[id] WHERE ([book_id] = ?)'),
 			$joinSql
 		);
 	} else {
 		Assert::same(
-			reformat('SELECT [Tag].[id] FROM [book_tag] LEFT JOIN [tag] AS [Tag] ON [book_tag].[tag_id] = [Tag].[id] WHERE ([book_id] = ?)'),
+			reformat('SELECT [Tag].[id] FROM [book_tag] LEFT JOIN [tag] [Tag] ON [book_tag].[tag_id] = [Tag].[id] WHERE ([book_id] = ?)'),
 			$joinSql
 		);
 	}


### PR DESCRIPTION
Oracle fails on `ORA-00905: missing keyword` when `AS` keyword is used.

When removed works on MySQL and Oracle. Please test other databases.