### PR TITLE
Fixed missing table exception

### DIFF
--- a/src/Database/Structure.php
+++ b/src/Database/Structure.php
@@ -137,7 +137,6 @@ class Structure extends Nette\Object implements IStructure
 	{
 		$this->structure = $this->loadStructure();
 		$this->cache->save('structure', $this->structure);
-		$this->isRebuilt = TRUE;
 	}
 
 
@@ -192,6 +191,8 @@ class Structure extends Nette\Object implements IStructure
 			}
 		}
 
+		$this->isRebuilt = TRUE;
+
 		return $structure;
 	}
 
@@ -239,6 +240,11 @@ class Structure extends Nette\Object implements IStructure
 
 		if (isset($this->structure['aliases'][$name])) {
 			return $this->structure['aliases'][$name];
+		}
+
+		if (!$this->isRebuilt()) {
+			$this->rebuild();
+			return $this->resolveFQTableName($table);
 		}
 
 		throw new Nette\InvalidArgumentException("Table '$name' does not exist.");

--- a/src/Database/Structure.php
+++ b/src/Database/Structure.php
@@ -47,10 +47,6 @@ class Structure extends Nette\Object implements IStructure
 		$this->needStructure();
 		$table = $this->resolveFQTableName($table);
 
-		if (!isset($this->structure['columns'][$table])) {
-			throw new Nette\InvalidArgumentException("Table '$table' does not exist.");
-		}
-
 		return $this->structure['columns'][$table];
 	}
 
@@ -245,7 +241,7 @@ class Structure extends Nette\Object implements IStructure
 			return $this->structure['aliases'][$name];
 		}
 
-		return $name;
+		throw new Nette\InvalidArgumentException("Table '$name' does not exist.");
 	}
 
 }

--- a/tests/Database/Structure.phpt
+++ b/tests/Database/Structure.phpt
@@ -122,7 +122,9 @@ class StructureTestCase extends TestCase
 	{
 		Assert::same('id', $this->structure->getPrimaryKey('books'));
 		Assert::same(['book_id', 'tag_id'], $this->structure->getPrimaryKey('Books_x_tags'));
-		Assert::null($this->structure->getPrimaryKey('invalid'));
+		Assert::exception(function() {
+			$this->structure->getPrimaryKey('invalid');
+		}, 'Nette\InvalidArgumentException', "Table 'invalid' does not exist.");
 	}
 
 

--- a/tests/Database/Table/Selection.get().phpt
+++ b/tests/Database/Table/Selection.get().phpt
@@ -22,4 +22,8 @@ test(function () use ($context) {
 		'title' => '1001 tipu a triku pro PHP',
 		'next_volume' => NULL,
 	], $book->toArray());
+
+	Assert::exception(function() use ($context){
+		$context->table('not_existing_table')->get(1);
+	}, 'Nette\InvalidArgumentException', "Table 'not_existing_table' does not exist.");
 });

--- a/tests/Database/Table/bugs/bug49.phpt
+++ b/tests/Database/Table/bugs/bug49.phpt
@@ -11,6 +11,7 @@ require __DIR__ . '/../../connect.inc.php';
 
 $context->query('CREATE DATABASE IF NOT EXISTS nette_test');
 $context->query('USE nette_test');
+$context->query('CREATE TABLE `TABLE 30` (id int)');
 
 Assert::same(
 	reformat('SELECT * FROM `TABLE 30`'),


### PR DESCRIPTION
- Fixes exceptions when trying to access to not existing table.
- When table not exists in cache, it try to reload structure like in case with foreign keys.

Fixes #79 