### PR TITLE
UniqueConstraintViolationException: Added getters for duplicate entry

### DIFF
--- a/src/Database/exceptions.php
+++ b/src/Database/exceptions.php
@@ -45,4 +45,43 @@ class NotNullConstraintViolationException extends ConstraintViolationException
  */
 class UniqueConstraintViolationException extends ConstraintViolationException
 {
+	/** @var string */
+	private $entry;
+
+	/** @var string */
+	private $key;
+
+
+	/**
+	 * @returns self
+	 */
+	public static function from(\PDOException $src)
+	{
+		$e = parent::from($src);
+
+		preg_match("/Duplicate entry '([^']+)' for key '([^']+)'/", $e->errorInfo[2], $m);
+		$e->entry = $m[1];
+		$e->key = $m[2];
+
+		return $e;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getEntry()
+	{
+		return $this->entry;
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function getKey()
+	{
+		return $this->key;
+	}
+
 }

--- a/tests/Database/ResultSet.exceptions.mysql.phpt
+++ b/tests/Database/ResultSet.exceptions.mysql.phpt
@@ -26,6 +26,8 @@ $e = Assert::exception(function () use ($context) {
 
 Assert::same(1062, $e->getDriverCode());
 Assert::same($e->getCode(), $e->getSqlState());
+Assert::same($e->getEntry(), '11');
+Assert::same($e->getKey(), 'PRIMARY');
 
 
 $e = Assert::exception(function () use ($context) {


### PR DESCRIPTION
I sometimes need to know which field caused duplicate entry error and add it to form error for example. I think this new getters will be helpfull for that. I am not sure about getter naming, so let me know if you have better ones.