### PR TITLE
Releted() query count

### DIFF
--- a/tests/Database/Table/bugs/query.count.phpt
+++ b/tests/Database/Table/bugs/query.count.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @dataProvider? ../../databases.ini
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../../files/{$driverName}-nette_test1.sql");
+
+// add additional tags (not relevant to other tests)
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (1, 24, 'private');");
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (2, 24, 'private');");
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (2, 22, 'private');");
+
+test(function () use ($connection, $context) {
+
+	$context->table('author')->get(11); // have to build cache first
+
+	$count = 0;
+	$connection->onQuery[] = function() use (&$count) {
+		$count ++;
+	};
+
+	foreach ($context->table('book') as $book) {
+		foreach ($book->related('book_tag_alt')->where('state', 'private') as $bookTag) {
+			$tag = $bookTag->tag;
+		}
+	}
+
+	Assert::same(3, $count);
+
+
+});


### PR DESCRIPTION
I've noticed some performance issues in v. 2.3.5, so I've written failing test. This test is passing in v. 2.3.4. This little bug kills my app really badly.

I don't underestant what is under the hood Nette/Database, I've spent a lot of time isolating this issue and  this test explains is quite well.

Should I create an Issue? or is failing test enought?