### PR TITLE
Referenced cache performance

### DIFF
--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -201,6 +201,11 @@ class GroupedSelection extends Selection
 		}
 	}
 
+	protected function emptyResultSet($saveCache = TRUE, $deleteRererencedCache = TRUE)
+	{
+		parent::emptyResultSet($saveCache, false);
+	}
+
 
 	/********************* manipulation ****************d*g**/
 

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -543,7 +543,7 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 	}
 
 
-	protected function emptyResultSet($saveCache = TRUE)
+	protected function emptyResultSet($saveCache = TRUE, $deleteRererencedCache = TRUE)
 	{
 		if ($this->rows !== NULL && $saveCache) {
 			$this->saveCacheState();
@@ -558,7 +558,9 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 		$this->specificCacheKey = NULL;
 		$this->generalCacheKey = NULL;
 		$this->refCache['referencingPrototype'] = [];
-		$this->refCache['referenced'] = [];
+		if ($deleteRererencedCache) {
+			$this->refCache['referenced'] = [];
+		}
 	}
 
 

--- a/tests/Database/Table/bugs/query.count.phpt
+++ b/tests/Database/Table/bugs/query.count.phpt
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @dataProvider? ../../databases.ini
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../../files/{$driverName}-nette_test1.sql");
+
+// add additional tags (not relevant to other tests)
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (1, 24, 'private');");
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (2, 24, 'private');");
+$context->query("INSERT INTO book_tag_alt (book_id, tag_id, state) VALUES (2, 22, 'private');");
+
+test(function () use ($connection, $context) {
+
+	$context->table('author')->get(11); // have to build cache first
+
+	$count = 0;
+	$connection->onQuery[] = function() use (&$count) {
+		$count ++;
+	};
+
+	foreach ($context->table('book') as $book) {
+		foreach ($book->related('book_tag_alt')->where('state', 'private') as $bookTag) {
+			$tag = $bookTag->tag;
+		}
+	}
+
+	Assert::same(3, $count);
+
+
+});


### PR DESCRIPTION
Selection: referenced cache cleared only for root selection (not in GroupedSelection), performance improvment

solves #91 