### PR TITLE
ActiveRow magic getter PhpDoc

### DIFF
--- a/src/Database/Table/ActiveRow.php
+++ b/src/Database/Table/ActiveRow.php
@@ -273,7 +273,11 @@ class ActiveRow implements \IteratorAggregate, IRow
 		throw new Nette\DeprecatedException('ActiveRow is read-only; use update() method instead.');
 	}
 
-
+	/**
+	 * @param string $key
+	 * @return ActiveRow|string|NULL
+	 * @throws Nette\MemberAccessException
+	 */
 	public function &__get($key)
 	{
 		$this->accessColumn($key);

--- a/src/Database/Table/ActiveRow.php
+++ b/src/Database/Table/ActiveRow.php
@@ -275,7 +275,7 @@ class ActiveRow implements \IteratorAggregate, IRow
 
 	/**
 	 * @param string $key
-	 * @return ActiveRow|string|NULL
+	 * @return ActiveRow|mixed
 	 * @throws Nette\MemberAccessException
 	 */
 	public function &__get($key)


### PR DESCRIPTION
When accessing a field from ActiveRow like `$row->field` PHPStorm infers the type to ActiveRow|NULL|FALSE and complains when passing the value to a function expecting for example an integer.

```php
/**
 * @param int $arg
 */
function foo($arg) {
}

foo($row->bar)
```

`Expected int, got FALSE|\Nette\Database\Table\ActiveRow|NULL`