### PR TITLE
MySqlDriver: added support of identifier with table prefix

### DIFF
--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -76,7 +76,7 @@ class MySqlDriver extends Nette\Object implements Nette\Database\ISupplementalDr
 	public function delimite($name)
 	{
 		// @see http://dev.mysql.com/doc/refman/5.0/en/identifiers.html
-		return '`' . str_replace('`', '``', $name) . '`';
+		return '`' . str_replace('.', '`.`', str_replace('`', '``', $name)) . '`';
 	}
 
 


### PR DESCRIPTION
Added support of identifier with table prefix like 'table.column' for delimite method. Generated UPDATE ... SET query contains invalid identifier in SET part, if the identifier have table prefix. So table.column is translated as \`table.column\`, instead of \`table\`.\`column\`. Othe clauses (SELECT, WHERE, ORDER) are translated right with table prefix used.