### PR TITLE
SqlsrvDriver::formatDateTime(): format datetime by ISO 8601

### DIFF
--- a/src/Database/Drivers/SqlsrvDriver.php
+++ b/src/Database/Drivers/SqlsrvDriver.php
@@ -63,7 +63,7 @@ class SqlsrvDriver extends Nette\Object implements Nette\Database\ISupplementalD
 	public function formatDateTime(/*\DateTimeInterface*/ $value)
 	{
 		/** @see https://msdn.microsoft.com/en-us/library/ms187819.aspx */
-		return $value->format("'Y-m-d H:i:s'");
+		return $value->format("'Y-m-d\TH:i:s'");
 	}
 
 

--- a/tests/Database/SqlPreprocessor.phpt
+++ b/tests/Database/SqlPreprocessor.phpt
@@ -253,6 +253,7 @@ test(function () use ($preprocessor, $driverName) { // date time
 	list($sql, $params) = $preprocessor->process(['SELECT ?', [new DateTime('2011-11-11')]]);
 	Assert::same(reformat([
 		'sqlite' => 'SELECT 1320966000',
+		'sqlsrv' => "SELECT '2011-11-11T00:00:00'",
 		"SELECT '2011-11-11 00:00:00'",
 	]), $sql);
 	Assert::same([], $params);
@@ -270,6 +271,7 @@ test(function () use ($preprocessor, $driverName) { // date time
 	list($sql, $params) = $preprocessor->process(['SELECT ?', [new DateTimeImmutable('2011-11-11')]]);
 	Assert::same(reformat([
 		'sqlite' => 'SELECT 1320966000',
+		'sqlsrv' => "SELECT '2011-11-11T00:00:00'",
 		"SELECT '2011-11-11 00:00:00'",
 	]), $sql);
 });
@@ -282,6 +284,7 @@ test(function () use ($preprocessor) { // insert
 
 	Assert::same(reformat([
 		'sqlite' => "INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', 1320966000)",
+		'sqlsrv' => "INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11T00:00:00')",
 		"INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11 00:00:00')",
 	]), $sql);
 	Assert::same([], $params);
@@ -324,6 +327,7 @@ test(function () use ($preprocessor) { // multi insert
 
 	Assert::same(reformat([
 		'sqlite' => "INSERT INTO author ([name], [born]) SELECT 'Catelyn Stark', 1320966000 UNION ALL SELECT 'Sansa Stark', 1636585200",
+		'sqlsrv' => "INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11T00:00:00'), ('Sansa Stark', '2021-11-11T00:00:00')",
 		"INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11 00:00:00'), ('Sansa Stark', '2021-11-11 00:00:00')",
 	]), $sql);
 	Assert::same([], $params);
@@ -338,6 +342,7 @@ test(function () use ($preprocessor) { // multi insert ?values
 
 	Assert::same(reformat([
 		'sqlite' => "INSERT INTO author ([name], [born]) SELECT 'Catelyn Stark', 1320966000 UNION ALL SELECT 'Sansa Stark', 1636585200",
+		'sqlsrv' => "INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11T00:00:00'), ('Sansa Stark', '2021-11-11T00:00:00')",
 		"INSERT INTO author ([name], [born]) VALUES ('Catelyn Stark', '2011-11-11 00:00:00'), ('Sansa Stark', '2021-11-11 00:00:00')",
 	]), $sql);
 	Assert::same([], $params);


### PR DESCRIPTION
When MS SQL save to datetime column, format 'Y-m-d H:i:s' is dependent on the SET LANGUAGE and SET DATETIME. Therefore it is better to use ISO 8601 format.

Documentation https://msdn.microsoft.com/en-us/library/ms187819.aspx says
The advantage in using the ISO 8601 format is that it is an international standard with unambiguous specification. Also, this format is not affected by the SET DATEFORMAT or SET LANGUAGE setting.