### PR TITLE
SqlBuilder: Added alias support

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -406,6 +406,20 @@ class Selection extends Nette\Object implements \Iterator, IRowContainer, \Array
 	}
 
 
+	/**
+	 * Alias table.
+	 * @example ':book:book_tag.tag', 'tg'
+	 * @param string
+	 * @param string
+	 * @return self
+	 */
+	public function alias($tableChain, $alias)
+	{
+		$this->sqlBuilder->addAlias($tableChain, $alias);
+		return $this;
+	}
+
+
 	/********************* aggregations ****************d*g**/
 
 

--- a/tests/Database/Table/SqlBuilder.addAlias().phpt
+++ b/tests/Database/Table/SqlBuilder.addAlias().phpt
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table\SqlBuilder: addAlias().
+ * @dataProvider? ../databases.ini
+ */
+
+use Tester\Assert;
+use Nette\Database\ISupplementalDriver;
+use Nette\Database\Table\SqlBuilder;
+
+require __DIR__ . '/../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
+
+class SqlBuilderMock extends SqlBuilder
+{
+	public function parseJoins(& $joins, & $query, $inner = FALSE)
+	{
+		parent::parseJoins($joins, $query);
+	}
+	public function buildQueryJoins(array $joins, $leftConditions = [])
+	{
+		return parent::buildQueryJoins($joins, $leftConditions);
+	}
+}
+
+$driver = $connection->getSupplementalDriver();
+
+
+test(function() use ($context, $driver) { // test duplicated table names throw exception
+	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
+		$sqlBuilder = new SqlBuilderMock('public.author', $context);
+	} else {
+		$sqlBuilder = new SqlBuilderMock('author', $context);
+	}
+	$sqlBuilder->addAlias(':book(translator)', 'book1');
+	$sqlBuilder->addAlias(':book:book_tag', 'book2');
+	Assert::exception(function() use ($sqlBuilder) {
+		$sqlBuilder->addAlias(':book', 'book1');
+	}, '\Nette\InvalidArgumentException');
+
+	Assert::exception(function() use ($sqlBuilder) { // reserved by base table name
+		$sqlBuilder->addAlias(':book', 'author');
+	}, '\Nette\InvalidArgumentException');
+
+	Assert::exception(function() use ($sqlBuilder) {
+		$sqlBuilder->addAlias(':book', 'book1');
+	}, '\Nette\InvalidArgumentException');
+
+	$sqlBuilder->addAlias(':book', 'tag');
+	Assert::exception(function() use ($sqlBuilder) {
+		$query = 'WHERE book1:book_tag.tag.id IS NULL';
+		$joins = [];
+		$sqlBuilder->parseJoins($joins, $query);
+	}, '\Nette\InvalidArgumentException');
+});
+
+
+test(function() use ($context, $driver) { // test same table chain with another alias
+	$sqlBuilder = new SqlBuilderMock('author', $context);
+	$sqlBuilder->addAlias(':book(translator)', 'translated_book');
+	$sqlBuilder->addAlias(':book(translator)', 'translated_book2');
+	$query = 'WHERE translated_book.translator_id IS NULL AND translated_book2.id IS NULL';
+	$joins = [];
+	$sqlBuilder->parseJoins($joins, $query);
+	$join = $sqlBuilder->buildQueryJoins($joins);
+
+	Assert::same(
+		'LEFT JOIN book translated_book ON author.id = translated_book.translator_id ' .
+		'LEFT JOIN book translated_book2 ON author.id = translated_book2.translator_id',
+		trim($join)
+	);
+});
+
+
+test(function() use ($context, $driver) { // test nested alias
+	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
+		$sqlBuilder = new SqlBuilderMock('public.author', $context);
+	} else {
+		$sqlBuilder = new SqlBuilderMock('author', $context);
+	}
+	$sqlBuilder->addAlias(':book(translator)', 'translated_book');
+	$sqlBuilder->addAlias('translated_book.next_volume', 'next');
+	$query = 'WHERE next.translator_id IS NULL';
+	$joins = [];
+	$sqlBuilder->parseJoins($joins, $query);
+	$join = $sqlBuilder->buildQueryJoins($joins);
+	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
+		Assert::same(
+			'LEFT JOIN book translated_book ON author.id = translated_book.translator_id ' .
+			'LEFT JOIN public.book next ON translated_book.next_volume = next.id',
+			trim($join)
+		);
+
+	} else {
+		Assert::same(
+			'LEFT JOIN book translated_book ON author.id = translated_book.translator_id ' .
+			'LEFT JOIN book next ON translated_book.next_volume = next.id',
+			trim($join)
+		);
+	}
+});


### PR DESCRIPTION
This patch allows to specify alias for given table chain. Aliases can be even nested. 

I have also added some checks if table alias is unique. Old behaviour in some cases silently skip tables or just works weird. It can found some hidden bugs in application. For example $context->table('book')->select('book.author.column') was translated to 'book.column'.
