### PR TITLE
Improved unique table name detection

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -551,7 +551,7 @@ class SqlBuilder extends Nette\Object
 				$tableAlias = preg_replace('#^(.*\.)?(.*)$#', '$2', $table);
 			}
 
-			$tableChain .= $keyMatch['del'] . $tableAlias;
+			$tableChain .= $keyMatch[0];
 			if (!$isLast || !$this->currentAlias) {
 				$this->checkUniqueTableName($tableAlias, $tableChain);
 			}

--- a/tests/Database/Table/SqlBuilder.addAlias().phpt
+++ b/tests/Database/Table/SqlBuilder.addAlias().phpt
@@ -51,6 +51,12 @@ test(function() use ($context, $driver) { // test duplicated table names throw e
 		$joins = [];
 		$sqlBuilder->parseJoins($joins, $query);
 	}, Nette\InvalidArgumentException::class, "Table alias 'tag' from chain '.book1:book_tag.tag' is already in use by chain ':book'. Please add/change alias for one of them.");
+
+	Assert::exception(function() use ($sqlBuilder) {
+		$query = 'WHERE :book(translator).id IS NULL AND :book.id IS NULL';
+		$joins = [];
+		$sqlBuilder->parseJoins($joins, $query);
+	}, Nette\InvalidArgumentException::class, "Table alias 'book' from chain ':book' is already in use by chain ':book(translator)'. Please add/change alias for one of them.");
 });
 
 

--- a/tests/Database/Table/SqlBuilder.addAlias().phpt
+++ b/tests/Database/Table/SqlBuilder.addAlias().phpt
@@ -29,11 +29,8 @@ $driver = $connection->getSupplementalDriver();
 
 
 test(function() use ($context, $driver) { // test duplicated table names throw exception
-	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
-		$sqlBuilder = new SqlBuilderMock('public.author', $context);
-	} else {
-		$sqlBuilder = new SqlBuilderMock('author', $context);
-	}
+	$authorTable = ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA) ? 'public.' : '' ) . 'author';
+	$sqlBuilder = new SqlBuilderMock($authorTable, $context);
 	$sqlBuilder->addAlias(':book(translator)', 'book1');
 	$sqlBuilder->addAlias(':book:book_tag', 'book2');
 	Assert::exception(function() use ($sqlBuilder) {
@@ -42,7 +39,7 @@ test(function() use ($context, $driver) { // test duplicated table names throw e
 
 	Assert::exception(function() use ($sqlBuilder) { // reserved by base table name
 		$sqlBuilder->addAlias(':book', 'author');
-	}, Nette\InvalidArgumentException::class, "Table alias 'author' from chain ':book' is already in use by chain 'author'. Please add/change alias for one of them.");
+	}, Nette\InvalidArgumentException::class, "Table alias 'author' from chain ':book' is already in use by chain '$authorTable'. Please add/change alias for one of them.");
 
 	Assert::exception(function() use ($sqlBuilder) {
 		$sqlBuilder->addAlias(':book', 'book1');


### PR DESCRIPTION
In previous patch, there was little mistake that checking of table name do not reflect specified column name (for example :book(translator) was evaluated exactly as :book).

There is also fix of test for postgres (@dg removes schema and now it's failing)
