### PR TITLE
SqlBuilder: Added ability to specify left join conditions

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -37,12 +37,16 @@ class SqlBuilder extends Nette\Object
 	/** @var array of where conditions */
 	protected $where = [];
 
+	/** @var array of array of join conditions */
+	protected $joinCondition = [];
+
 	/** @var array of where conditions for caching */
 	protected $conditions = [];
 
 	/** @var array of parameters passed to where conditions */
 	protected $parameters = [
 		'select' => [],
+		'joinCondition' => [],
 		'where' => [],
 		'group' => [],
 		'having' => [],
@@ -81,6 +85,9 @@ class SqlBuilder extends Nette\Object
 
 	/** @var array */
 	private $cacheTableList;
+
+	/** @var array of expanding joins */
+	private $expandingJoins = [];
 
 
 	public function __construct($tableName, Context $context)
@@ -142,10 +149,12 @@ class SqlBuilder extends Nette\Object
 			);
 		}
 
+		$queryJoinConditions = $this->buildJoinConditions();
 		$queryCondition = $this->buildConditions();
 		$queryEnd = $this->buildQueryEnd();
 
 		$joins = [];
+		$finalJoinConditions = $this->parseJoinConditions($joins, $queryJoinConditions);
 		$this->parseJoins($joins, $queryCondition);
 		$this->parseJoins($joins, $queryEnd);
 
@@ -170,7 +179,7 @@ class SqlBuilder extends Nette\Object
 			$querySelect = $this->buildSelect([$prefix . '*']);
 		}
 
-		$queryJoins = $this->buildQueryJoins($joins);
+		$queryJoins = $this->buildQueryJoins($joins, $finalJoinConditions);
 		$query = "{$querySelect} FROM {$this->delimitedTable}{$queryJoins}{$queryCondition}{$queryEnd}";
 
 		$this->driver->applyLimit($query, $this->limit, $this->offset);
@@ -181,8 +190,12 @@ class SqlBuilder extends Nette\Object
 
 	public function getParameters()
 	{
+		if (!isset($this->parameters['joinConditionSorted'])) {
+			$this->buildSelectQuery();
+		}
 		return array_merge(
 			$this->parameters['select'],
+			$this->parameters['joinConditionSorted'] ? call_user_func_array('array_merge', $this->parameters['joinConditionSorted']) : [],
 			$this->parameters['where'],
 			$this->parameters['group'],
 			$this->parameters['having'],
@@ -194,7 +207,9 @@ class SqlBuilder extends Nette\Object
 	public function importConditions(SqlBuilder $builder)
 	{
 		$this->where = $builder->where;
+		$this->joinCondition = $builder->joinCondition;
 		$this->parameters['where'] = $builder->parameters['where'];
+		$this->parameters['joinCondition'] = $builder->parameters['joinCondition'];
 		$this->conditions = $builder->conditions;
 	}
 
@@ -220,8 +235,24 @@ class SqlBuilder extends Nette\Object
 
 	public function addWhere($condition, ...$params)
 	{
+		return $this->addCondition($condition, $params, $this->where, $this->parameters['where']);
+	}
+
+
+	public function addJoinCondition($tableChain, $condition, ...$params)
+	{
+		$this->parameters['joinConditionSorted'] = NULL;
+		if (!isset($this->joinCondition[$tableChain])) {
+			$this->joinCondition[$tableChain] = $this->parameters['joinCondition'][$tableChain] = [];
+		}
+		return $this->addCondition($condition, $params, $this->joinCondition[$tableChain], $this->parameters['joinCondition'][$tableChain]);
+	}
+
+
+	protected function addCondition($condition, array $params, array & $conditions, array & $conditionsParameters)
+	{
 		if (is_array($condition) && !empty($params[0]) && is_array($params[0])) {
-			return $this->addWhereComposition($condition, $params[0]);
+			return $this->addConditionComposition($condition, $params[0], $conditions, $conditionsParameters);
 		}
 
 		$hash = $this->getConditionHash($condition, $params);
@@ -281,7 +312,7 @@ class SqlBuilder extends Nette\Object
 					if ($this->driver->isSupported(ISupplementalDriver::SUPPORT_SUBSELECT)) {
 						$arg = NULL;
 						$replace = $match[2][0] . '(' . $clone->getSql() . ')';
-						$this->parameters['where'] = array_merge($this->parameters['where'], $clone->getSqlBuilder()->getParameters());
+						$conditionsParameters = array_merge($conditionsParameters, $clone->getSqlBuilder()->getParameters());
 					} else {
 						$arg = [];
 						foreach ($clone as $row) {
@@ -307,16 +338,16 @@ class SqlBuilder extends Nette\Object
 						$arg = NULL;
 					} else {
 						$replace = $match[2][0] . '(?)';
-						$this->parameters['where'][] = $arg;
+						$conditionsParameters[] = $arg;
 					}
 				}
 			} elseif ($arg instanceof SqlLiteral) {
-				$this->parameters['where'][] = $arg;
+				$conditionsParameters[] = $arg;
 			} else {
 				if (!$hasOperator) {
 					$replace = '= ?';
 				}
-				$this->parameters['where'][] = $arg;
+				$conditionsParameters[] = $arg;
 			}
 
 			if ($replace) {
@@ -329,7 +360,7 @@ class SqlBuilder extends Nette\Object
 			}
 		}
 
-		$this->where[] = $condition;
+		$conditions[] = $condition;
 		return TRUE;
 	}
 
@@ -443,18 +474,90 @@ class SqlBuilder extends Nette\Object
 	}
 
 
+	protected function parseJoinConditions(& $joins, $joinConditions)
+	{
+		$tableJoins = $leftJoinDependency = $finalJoinConditions = [];
+		foreach ($joinConditions as $tableChain => & $joinCondition) {
+			$fooQuery = $tableChain . '.foo';
+			$requiredJoins = [];
+			$this->parseJoins($requiredJoins, $fooQuery);
+			$tableAlias = substr($fooQuery, 0, -4);
+			$tableJoins[$tableAlias] = $requiredJoins;
+			$leftJoinDependency[$tableAlias] = [];
+			$finalJoinConditions[$tableAlias] = preg_replace_callback($this->getColumnChainsRegxp(), function ($match) use ($tableAlias, & $tableJoins, & $leftJoinDependency) {
+				$requiredJoins = [];
+				$query = $this->parseJoinsCb($requiredJoins, $match);
+				$queryParts = explode('.', $query);
+				$tableJoins[$queryParts[0]] = $requiredJoins;
+				if ($queryParts[0] !== $tableAlias) {
+					foreach (array_keys($requiredJoins) as $requiredTable) {
+						$leftJoinDependency[$tableAlias][$requiredTable] = $requiredTable;
+					}
+				}
+				return $query;
+			}, $joinCondition);
+		}
+		$this->parameters['joinConditionSorted'] = [];
+		if (count($joinConditions)) {
+			while (reset($tableJoins)) {
+				$this->getSortedJoins(key($tableJoins), $leftJoinDependency, $tableJoins, $joins);
+			}
+		}
+		return $finalJoinConditions;
+	}
+
+
+	protected function getSortedJoins($table, &$leftJoinDependency, &$tableJoins, &$finalJoins)
+	{
+		if (isset($this->expandingJoins[$table])) {
+			$path = implode("' => '", array_map(function($value) { return $this->reservedTableNames[$value]; }, array_merge(array_keys($this->expandingJoins), [$table])));
+			throw new Nette\InvalidArgumentException("Circular reference detected at left join conditions (tables '$path').");
+		}
+		if (isset($tableJoins[$table])) {
+			$this->expandingJoins[$table] = TRUE;
+			if (isset($leftJoinDependency[$table])) {
+				foreach ($leftJoinDependency[$table] as $requiredTable) {
+					if ($requiredTable === $table) {
+						continue;
+					}
+					$this->getSortedJoins($requiredTable, $leftJoinDependency, $tableJoins, $finalJoins);
+				}
+			}
+			if ($tableJoins[$table]) {
+				foreach ($tableJoins[$table] as $requiredTable => $tmp) {
+					if ($requiredTable === $table) {
+						continue;
+					}
+					$this->getSortedJoins($requiredTable, $leftJoinDependency, $tableJoins, $finalJoins);
+				}
+			}
+			$finalJoins += $tableJoins[$table];
+			$this->parameters['joinConditionSorted'] += (isset($this->parameters['joinCondition'][$this->reservedTableNames[$table]])
+							? [$table => $this->parameters['joinCondition'][$this->reservedTableNames[$table]]]
+							: []);
+			unset($tableJoins[$table]);
+			unset($this->expandingJoins[$table]);
+		}
+	}
+
+
 	protected function parseJoins(& $joins, & $query)
 	{
-		$query = preg_replace_callback('~
+		$query = preg_replace_callback($this->getColumnChainsRegxp(), function ($match) use (& $joins) {
+			return $this->parseJoinsCb($joins, $match);
+		}, $query);
+	}
+
+
+	private function getColumnChainsRegxp() {
+		return '~
 			(?(DEFINE)
 				(?P<word> [\w_]*[a-z][\w_]* )
 				(?P<del> [.:] )
 				(?P<node> (?&del)? (?&word) (\((?&word)\))? )
 			)
 			(?P<chain> (?!\.) (?&node)*)  \. (?P<column> (?&word) | \*  )
-		~xi', function ($match) use (& $joins) {
-			return $this->parseJoinsCb($joins, $match);
-		}, $query);
+		~xi';
 	}
 
 
@@ -564,15 +667,26 @@ class SqlBuilder extends Nette\Object
 	}
 
 
-	protected function buildQueryJoins(array $joins)
+	protected function buildQueryJoins(array $joins, array $leftJoinConditions = [])
 	{
 		$return = '';
 		foreach ($joins as list($joinTable, $joinAlias, $table, $tableColumn, $joinColumn)) {
 			$return .=
 				" LEFT JOIN {$joinTable}" . ($joinTable !== $joinAlias ? " {$joinAlias}" : '') .
-				" ON {$table}.{$tableColumn} = {$joinAlias}.{$joinColumn}";
+				" ON {$table}.{$tableColumn} = {$joinAlias}.{$joinColumn}" .
+				(isset($leftJoinConditions[$joinAlias]) ? " {$leftJoinConditions[$joinAlias]}" : '');
 		}
 		return $return;
+	}
+
+
+	protected function buildJoinConditions()
+	{
+		$conditions = [];
+		foreach ($this->joinCondition as $tableChain => $joinConditions) {
+			$conditions[$tableChain] = 'AND (' . implode(') AND (', $joinConditions) . ')';
+		}
+		return $conditions;
 	}
 
 
@@ -606,14 +720,14 @@ class SqlBuilder extends Nette\Object
 	}
 
 
-	protected function addWhereComposition(array $columns, array $parameters)
+	protected function addConditionComposition(array $columns, array $parameters, array & $conditions, array & $conditionsParameters)
 	{
 		if ($this->driver->isSupported(ISupplementalDriver::SUPPORT_MULTI_COLUMN_AS_OR_COND)) {
 			$conditionFragment = '(' . implode(' = ? AND ', $columns) . ' = ?) OR ';
 			$condition = substr(str_repeat($conditionFragment, count($parameters)), 0, -4);
-			return $this->addWhere($condition, Nette\Utils\Arrays::flatten($parameters));
+			return $this->addCondition($condition, [Nette\Utils\Arrays::flatten($parameters)], $conditions, $conditionsParameters);
 		} else {
-			return $this->addWhere('(' . implode(', ', $columns) . ') IN', $parameters);
+			return $this->addCondition('(' . implode(', ', $columns) . ') IN', [$parameters], $conditions, $conditionsParameters);
 		}
 	}
 

--- a/tests/Database/Table/SqlBuilder.addAlias().phpt
+++ b/tests/Database/Table/SqlBuilder.addAlias().phpt
@@ -19,9 +19,9 @@ class SqlBuilderMock extends SqlBuilder
 	{
 		parent::parseJoins($joins, $query);
 	}
-	public function buildQueryJoins(array $joins, $leftConditions = [])
+	public function buildQueryJoins(array $joins, array $leftJoinConditions = [])
 	{
-		return parent::buildQueryJoins($joins, $leftConditions);
+		return parent::buildQueryJoins($joins, $leftJoinConditions);
 	}
 }
 

--- a/tests/Database/Table/SqlBuilder.parseJoinConditions().phpt
+++ b/tests/Database/Table/SqlBuilder.parseJoinConditions().phpt
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table\SqlBuilder: parseJoinConditions().
+ * @dataProvider? ../databases.ini
+ */
+
+use Tester\Assert;
+use Nette\Database\ISupplementalDriver;
+use Nette\Database\Table\SqlBuilder;
+
+require __DIR__ . '/../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
+
+class SqlBuilderMock extends SqlBuilder
+{
+	public function parseJoinConditions(& $joins, $joinConditions)
+	{
+		return parent::parseJoinConditions($joins, $joinConditions);
+	}
+	public function buildJoinConditions()
+	{
+		return parent::buildJoinConditions();
+	}
+	public function parseJoins(& $joins, & $query)
+	{
+		parent::parseJoins($joins, $query);
+	}
+	public function buildQueryJoins(array $joins, array $leftJoinConditions = [])
+	{
+		return parent::buildQueryJoins($joins, $leftJoinConditions);
+	}
+}
+
+$driver = $connection->getSupplementalDriver();
+
+test(function() use ($context) { // test circular reference
+	$sqlBuilder = new SqlBuilderMock('author', $context);
+	$sqlBuilder->addJoinCondition(':book(translator)', ':book(translator).translator_id = :book(translator).next_volume.translator_id');
+	Assert::exception(function() use ($sqlBuilder){
+		$sqlBuilder->buildSelectQuery();
+	}, Nette\InvalidArgumentException::class, "Circular reference detected at left join conditions (tables ':book(translator)' => ':book(translator).next_volume' => ':book(translator)').");
+
+	$sqlBuilder = new SqlBuilderMock('author', $context);
+	$sqlBuilder->addJoinCondition(':book.next_volume', ':book.next_volume.translator_id = :book.translator.id');
+	$sqlBuilder->addJoinCondition(':book.translator', ':book.translator.id = :book.next_volume.translator_id');
+	Assert::exception(function() use ($sqlBuilder){
+		$sqlBuilder->buildSelectQuery();
+	}, Nette\InvalidArgumentException::class, "Circular reference detected at left join conditions (tables ':book.next_volume' => ':book.translator' => ':book.next_volume').");
+
+	$sqlBuilder = new SqlBuilderMock('author', $context);
+	$sqlBuilder->addJoinCondition(':book.next_volume', ':book.next_volume.translator_id = :book.translator.id');
+	$sqlBuilder->addJoinCondition(':book.translator', ':book.translator.id = :book.auth.id');
+	$sqlBuilder->addJoinCondition(':book.auth', ':book.auth.id = :book.next_volume.author_id');
+	Assert::exception(function() use ($sqlBuilder){
+		$sqlBuilder->buildSelectQuery();
+	}, Nette\InvalidArgumentException::class, "Circular reference detected at left join conditions (tables ':book.next_volume' => ':book.translator' => ':book.auth' => ':book.next_volume').");
+});
+
+test(function() use ($context, $driver) {
+	$sqlBuilder = new SqlBuilderMock('author', $context);
+	$sqlBuilder->addJoinCondition(':book(translator)', ':book(translator).id > ?', 2);
+	$sqlBuilder->addJoinCondition(':book(translator):book_tag_alt', ':book(translator):book_tag_alt.state ?', 'private');
+	$joins = [];
+	$leftJoinConditions = $sqlBuilder->parseJoinConditions($joins, $sqlBuilder->buildJoinConditions());
+	$join = $sqlBuilder->buildQueryJoins($joins, $leftJoinConditions);
+
+	if ($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
+		Assert::same(
+			'LEFT JOIN book ON author.id = book.translator_id AND (book.id > ?) ' .
+			'LEFT JOIN public.book_tag_alt book_tag_alt ON book.id = book_tag_alt.book_id AND (book_tag_alt.state = ?)',
+			trim($join)
+		);
+	} else {
+		Assert::same(
+			'LEFT JOIN book ON author.id = book.translator_id AND (book.id > ?) ' .
+			'LEFT JOIN book_tag_alt ON book.id = book_tag_alt.book_id AND (book_tag_alt.state = ?)',
+			trim($join)
+		);
+	}
+	Assert::same([2, 'private'], $sqlBuilder->getParameters());
+});

--- a/tests/Database/Table/SqlBuilder.parseJoins().phpt
+++ b/tests/Database/Table/SqlBuilder.parseJoins().phpt
@@ -21,9 +21,9 @@ class SqlBuilderMock extends SqlBuilder
 	{
 		parent::parseJoins($joins, $query);
 	}
-	public function buildQueryJoins(array $joins)
+	public function buildQueryJoins(array $joins, array $leftJoinConditions = [])
 	{
-		return parent::buildQueryJoins($joins);
+		return parent::buildQueryJoins($joins, $leftJoinConditions);
 	}
 }
 

--- a/tests/Database/Table/Table.join-condition.phpt
+++ b/tests/Database/Table/Table.join-condition.phpt
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table: Additional join condition
+ * @dataProvider? ../databases.ini
+ */
+
+use Nette\Database\ISupplementalDriver;
+use Tester\Assert;
+
+require __DIR__ . '/../connect.inc.php'; // create $connection
+
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
+$driver = $connection->getSupplementalDriver();
+test(function() use ($context, $driver) {
+	$schema = $driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA) ? '[public].' : '';
+	$sql = $context->table('book')->joinWhere('translator', 'translator.name', 'Geek')->select('book.*')->getSql();
+
+	Assert::same(reformat(
+		"SELECT [book].* FROM [book] " .
+		"LEFT JOIN {$schema}[author] [translator] ON [book].[translator_id] = [translator].[id] AND ([translator].[name] = ?)"
+	), $sql);
+});
+
+test(function() use ($context, $driver){
+	$sql = $context->table('tag')
+		->select('tag.name, COUNT(:book_tag.book.id) AS count_of_next_volume_written_by_younger_author')
+		->joinWhere(':book_tag.book.author', ':book_tag.book.author.born < next_volume_author.born')
+		->alias(':book_tag.book.next_volume.author', 'next_volume_author')
+		->where('tag.name', 'PHP')
+		->group('tag.name')
+		->getSql();
+	if($driver->isSupported(ISupplementalDriver::SUPPORT_SCHEMA)) {
+		Assert::same(reformat(
+			"SELECT [tag].[name], COUNT([book].[id]) AS [count_of_next_volume_written_by_younger_author] FROM [tag] " .
+			"LEFT JOIN [public].[book_tag] [book_tag] ON [tag].[id] = [book_tag].[tag_id] " .
+			"LEFT JOIN [public].[book] [book] ON [book_tag].[book_id] = [book].[id] " .
+			"LEFT JOIN [public].[book] [book_ref] ON [book].[next_volume] = [book_ref].[id] " .
+			"LEFT JOIN [public].[author] [next_volume_author] ON [book_ref].[author_id] = [next_volume_author].[id] " .
+			"LEFT JOIN [public].[author] [author] ON [book].[author_id] = [author].[id] AND ([author].[born] < [next_volume_author].[born]) " .
+			"WHERE ([tag].[name] = ?) " .
+			"GROUP BY [tag].[name]"), $sql);
+	} else {
+		Assert::same(reformat(
+			"SELECT [tag].[name], COUNT([book].[id]) AS [count_of_next_volume_written_by_younger_author] FROM [tag] " .
+			"LEFT JOIN [book_tag] ON [tag].[id] = [book_tag].[tag_id] " .
+			"LEFT JOIN [book] ON [book_tag].[book_id] = [book].[id] " .
+			"LEFT JOIN [book] [book_ref] ON [book].[next_volume] = [book_ref].[id] " .
+			"LEFT JOIN [author] [next_volume_author] ON [book_ref].[author_id] = [next_volume_author].[id] " .
+			"LEFT JOIN [author] ON [book].[author_id] = [author].[id] AND ([author].[born] < [next_volume_author].[born]) " .
+			"WHERE ([tag].[name] = ?) " .
+			"GROUP BY [tag].[name]"), $sql);
+	}
+});


### PR DESCRIPTION
Thanks to this patch it is possible to specify additional conditions for ON clause of left joins.

Usage is very similar to specify normal condition.

Example:
```
$context->table('book')->joinWhere('translator' /*$tableChain*/, 'translator.name' /*$condition*/, 'David Grudl' /* $params*/);
```
Over proposal at #35, this patch support conditions specified by columns from other tables. It means  that I'm not able to assign conditions to joined table automatically, but it has to be specified at first parameter.

What do you think about API? I was thinking about  whereSoft and others mentioned at #35 and nette/nette/#1436, but I think that this is more understandable. 

@hrach probably would not agree with me, but I think that the main advantage of nette database is simplicity, not that I do not know what (LEFT) JOIN.


