### PR TITLE
Performance > It prevents multiple parse of query parts by regular expresions

### DIFF
--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -87,7 +87,7 @@ class GroupedSelection extends Selection
 
 	public function aggregation($function)
 	{
-		$aggregation = & $this->getRefTable($refPath)->aggregation[$refPath . $function . $this->getSql() . json_encode($this->sqlBuilder->getParameters())];
+		$aggregation = & $this->getRefTable($refPath)->aggregation[$refPath . $function . $this->sqlBuilder->getSelectQueryHash($this->getPreviousAccessedColumns())];
 
 		if ($aggregation === NULL) {
 			$aggregation = [];

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -680,7 +680,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 			return $this->specificCacheKey;
 		}
 
-		return $this->specificCacheKey = md5($this->getSql() . json_encode($this->sqlBuilder->getParameters()));
+		return $this->specificCacheKey = $this->sqlBuilder->getSelectQueryHash($this->getPreviousAccessedColumns());
 	}
 
 

--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -137,6 +137,39 @@ class SqlBuilder
 
 
 	/**
+	 * Returns select query hash for caching.
+	 * @return string
+	 */
+	public function getSelectQueryHash($columns = NULL)
+	{
+		$parts = [
+			'delimitedTable' => $this->delimitedTable,
+			'queryCondition' => $this->buildConditions(),
+			'queryEnd' => $this->buildQueryEnd(),
+			$this->aliases,
+			$this->limit, $this->offset,
+		];
+		if ($this->select) {
+			$parts[] = $this->select;
+		} elseif ($columns) {
+			$parts[] = [$this->delimitedTable, $columns];
+		} elseif ($this->group && !$this->driver->isSupported(ISupplementalDriver::SUPPORT_SELECT_UNGROUPED_COLUMNS)) {
+			$parts[] = [$this->group];
+		} else {
+			$parts[] = "{$this->delimitedTable}.*";
+		}
+		return $this->getConditionHash(json_encode($parts), array_merge(
+			$this->parameters['select'],
+			$this->parameters['joinCondition'] ? call_user_func_array('array_merge', $this->parameters['joinCondition']) : [],
+			$this->parameters['where'],
+			$this->parameters['group'],
+			$this->parameters['having'],
+			$this->parameters['order']
+		));
+	}
+
+
+	/**
 	 * Returns SQL query.
 	 * @param  string list of columns
 	 * @return string


### PR DESCRIPTION
I was debugging export of products becase it takes too much time. At blackfire.io I found that 20% of all time takes resolving cache keys. Problem was with repeated parsing of query parts with regular expressions, that is not necessary for getting cache key. This patch can saves lot of time if you working with large datasets...