### PR TITLE
Debugger Connection Panel explain block - non breakable spaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "nette/database",
+	"name": "WyskyNet/database",
 	"description": "Nette Database Component",
 	"homepage": "https://nette.org",
 	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "WyskyNet/database",
+	"name": "nette/database",
 	"description": "Nette Database Component",
 	"homepage": "https://nette.org",
 	"license": ["BSD-3-Clause", "GPL-2.0", "GPL-3.0"],

--- a/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
+++ b/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
@@ -42,7 +42,7 @@ use Nette,
 			<?php foreach ($explain as $row): ?>
 			<tr>
 			<?php foreach ($row as $col): ?>
-				<td><?= htmlSpecialChars($col, ENT_NOQUOTES, 'UTF-8') ?></td>
+				<td><?= str_replace(' ', '&nbsp;', htmlSpecialChars($col, ENT_NOQUOTES, 'UTF-8')) ?></td>
 			<?php endforeach ?>
 			</tr>
 			<?php endforeach ?>


### PR DESCRIPTION
Tiny styling fix for explain block in database connection panel...

![current](https://cloud.githubusercontent.com/assets/5887684/15395293/68466fb4-1dd7-11e6-9f84-9b51953e3434.png)
![formatted](https://cloud.githubusercontent.com/assets/5887684/15395294/68489780-1dd7-11e6-9f0f-90cd82adb303.png)
