### PR TITLE
Add support for limit in update and delete queries for MySQL driver

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -120,19 +120,23 @@ class SqlBuilder
 
 	public function buildUpdateQuery()
 	{
+		$query = "UPDATE {$this->delimitedTable} SET ?set" . $this->tryDelimite($this->buildConditions());
 		if ($this->limit !== NULL || $this->offset) {
-			throw new Nette\NotSupportedException('LIMIT clause is not supported in UPDATE query.');
+			$this->driver->applyLimit($query, $this->limit, $this->offset);
 		}
-		return "UPDATE {$this->delimitedTable} SET ?set" . $this->tryDelimite($this->buildConditions());
+
+		return $query;
 	}
 
 
 	public function buildDeleteQuery()
 	{
+		$query = "DELETE FROM {$this->delimitedTable}" . $this->tryDelimite($this->buildConditions());
 		if ($this->limit !== NULL || $this->offset) {
-			throw new Nette\NotSupportedException('LIMIT clause is not supported in DELETE query.');
+			$this->driver->applyLimit($query, $this->limit, $this->offset);
 		}
-		return "DELETE FROM {$this->delimitedTable}" . $this->tryDelimite($this->buildConditions());
+
+		return $query;
 	}
 
 


### PR DESCRIPTION
Hi,

I've prepared this pull request as solution for issue #120. It add support for limit in update and delete queries in MySQL as desribed in documentation http://dev.mysql.com/doc/refman/5.7/en/update.html + http://dev.mysql.com/doc/refman/5.7/en/delete.html.

It add new constants to ISupplementalDriver SUPPORT_UPDATE_LIMIT and SUPPORT_DELETE_LIMIT so each driver can define support. If it's not supported, then is throw same exception as before.