### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 	"require": {
 		"php": ">=5.3.1",
 		"ext-pdo": "*",
-		"nette/caching": "^2.2",
+		"nette/caching": "~2.2",
 		"nette/utils": "^2.3.5"
 	},
 	"require-dev": {


### PR DESCRIPTION
Bad dependency here.  With carret symbol (^) i get latest 2.4.x package and it is undesirable for package 2.3 and compatibility with older PHP (PHP 5.3).