### PR TITLE
Create new instance with keyword static.

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -599,7 +599,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 
 	public function createSelectionInstance($table = NULL)
 	{
-		return new self($this->context, $this->conventions, $table ?: $this->name, $this->cache ? $this->cache->getStorage() : NULL);
+		return new static($this->context, $this->conventions, $table ?: $this->name, $this->cache ? $this->cache->getStorage() : NULL);
 	}
 
 


### PR DESCRIPTION
All property of class Selection are protected, if I want extend Selection class and use my new class, I must copy createSelectionInstance.