### PR TITLE
Fix php version range for Connection::getLastInsertId().

### DIFF
--- a/tests/Database/Connection.getInsertId().postgre.phpt
+++ b/tests/Database/Connection.getInsertId().postgre.phpt
@@ -21,10 +21,10 @@ $connection->query('
 ');
 
 $connection->query('INSERT INTO primarykey (prim) VALUES (5)');
-Assert::equal(PHP_VERSION_ID < 70011 ? FALSE : '0', $connection->getInsertId());
+Assert::equal(PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70011 || PHP_VERSION_ID < 50626 ? FALSE : '0', $connection->getInsertId());
 
 $connection->query('INSERT INTO primarykey (prim) VALUES (6)');
-Assert::equal(PHP_VERSION_ID < 70011 ? FALSE : '0', $connection->getInsertId());
+Assert::equal(PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70011 || PHP_VERSION_ID < 50626 ? FALSE : '0', $connection->getInsertId());
 
 
 $connection->query('


### PR DESCRIPTION
- bug fix? yes [nette forum](https://forum.nette.org/cs/27827-padaji-testy-pro-postgresql)
- BC break? no

Hi,
i run test for postgresql and than fail and i found in php [changelog](http://php.net/ChangeLog-5.php#5.6.26) the behavior was changed like php 7.0.11+.
