### PR TITLE
ResultSet: change fetch() and fetchField() methods result from FALSE to NULL

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -212,7 +212,7 @@ class Connection
 	/**
 	 * Shortcut for query()->fetch()
 	 * @param  string
-	 * @return Row
+	 * @return Row|NULL
 	 */
 	public function fetch($sql, ...$params)
 	{
@@ -223,7 +223,7 @@ class Connection
 	/**
 	 * Shortcut for query()->fetchField()
 	 * @param  string
-	 * @return mixed
+	 * @return mixed|NULL
 	 */
 	public function fetchField($sql, ...$params)
 	{

--- a/src/Database/Context.php
+++ b/src/Database/Context.php
@@ -131,7 +131,7 @@ class Context
 	/**
 	 * Shortcut for query()->fetch()
 	 * @param  string
-	 * @return Row
+	 * @return Row|NULL
 	 */
 	public function fetch($sql, ...$params)
 	{
@@ -142,7 +142,7 @@ class Context
 	/**
 	 * Shortcut for query()->fetchField()
 	 * @param  string
-	 * @return mixed
+	 * @return mixed|NULL
 	 */
 	public function fetchField($sql, ...$params)
 	{

--- a/src/Database/IRowContainer.php
+++ b/src/Database/IRowContainer.php
@@ -18,7 +18,7 @@ interface IRowContainer extends \Traversable
 
 	/**
 	 * Fetches single row object.
-	 * @return IRow|bool if there is no row
+	 * @return IRow|NULL if there is no row
 	 */
 	function fetch();
 

--- a/src/Database/IRowContainer.php
+++ b/src/Database/IRowContainer.php
@@ -23,6 +23,13 @@ interface IRowContainer extends \Traversable
 	function fetch();
 
 	/**
+	 * Fetches single field.
+	 * @param  int
+	 * @return mixed|NULL
+	 */
+	function fetchField($column = 0);
+
+	/**
 	 * Fetches all rows as associative array.
 	 * @param  string column name used for an array key or NULL for numeric index
 	 * @param  string column name used for an array value or NULL for the whole row

--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -239,7 +239,7 @@ class ResultSet implements \Iterator, IRowContainer
 			return TRUE;
 		}
 
-		return $this->fetch() !== FALSE;
+		return $this->fetch() !== NULL;
 	}
 
 
@@ -254,7 +254,7 @@ class ResultSet implements \Iterator, IRowContainer
 		$data = $this->pdoStatement ? $this->pdoStatement->fetch() : NULL;
 		if (!$data) {
 			$this->pdoStatement->closeCursor();
-			return FALSE;
+			return NULL;
 
 		} elseif ($this->result === NULL && count($data) !== $this->pdoStatement->columnCount()) {
 			$duplicates = Helpers::findDuplicates($this->pdoStatement);
@@ -276,12 +276,12 @@ class ResultSet implements \Iterator, IRowContainer
 	/**
 	 * Fetches single field.
 	 * @param  int
-	 * @return mixed|FALSE
+	 * @return mixed|NULL
 	 */
 	public function fetchField($column = 0)
 	{
 		$row = $this->fetch();
-		return $row ? $row[$column] : FALSE;
+		return $row ? $row[$column] : NULL;
 	}
 
 

--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -274,9 +274,7 @@ class ResultSet implements \Iterator, IRowContainer
 
 
 	/**
-	 * Fetches single field.
-	 * @param  int
-	 * @return mixed|NULL
+	 * @inheritDoc
 	 */
 	public function fetchField($column = 0)
 	{

--- a/src/Database/Table/ActiveRow.php
+++ b/src/Database/Table/ActiveRow.php
@@ -183,7 +183,7 @@ class ActiveRow implements \IteratorAggregate, IRow
 					->wherePrimary($tmp + $primary);
 			}
 			$selection->select('*');
-			if (($row = $selection->fetch()) === FALSE) {
+			if (($row = $selection->fetch()) === NULL) {
 				throw new Nette\InvalidStateException('Database refetch failed; row does not exist!');
 			}
 			$this->data = $row->data;

--- a/src/Database/Table/IRowContainer.php
+++ b/src/Database/Table/IRowContainer.php
@@ -15,7 +15,7 @@ use Nette\Database;
 /**
  * Container of database result fetched into IRow objects.
  *
- * @method     IRow|bool  fetch() Fetches single row object.
+ * @method     IRow|NULL  fetch() Fetches single row object.
  * @method     IRow[]     fetchAll() Fetches all rows.
  */
 interface IRowContainer extends Database\IRowContainer

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -170,7 +170,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	/**
 	 * Loads cache of previous accessed columns and returns it.
 	 * @internal
-	 * @return array|false
+	 * @return array|FALSE
 	 */
 	public function getPreviousAccessedColumns()
 	{
@@ -201,7 +201,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	/**
 	 * Returns row specified by primary key.
 	 * @param  mixed primary key
-	 * @return IRow or FALSE if there is no such row
+	 * @return IRow or NULL if there is no such row
 	 */
 	public function get($key)
 	{
@@ -218,14 +218,14 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 		$this->execute();
 		$return = current($this->data);
 		next($this->data);
-		return $return;
+		return $return === FALSE ? NULL : $return;
 	}
 
 
 	/**
 	 * Fetches single field.
 	 * @param  string|NULL
-	 * @return mixed|FALSE
+	 * @return mixed|NULL
 	 */
 	public function fetchField($column = NULL)
 	{
@@ -238,7 +238,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 			return $column ? $row[$column] : array_values($row->toArray())[0];
 		}
 
-		return FALSE;
+		return NULL;
 	}
 
 
@@ -992,7 +992,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	}
 
 
-	/** @return IRow */
+	/** @return IRow|bool */
 	public function current()
 	{
 		if (($key = current($this->keys)) !== FALSE) {

--- a/tests/Database/Context.transaction.phpt
+++ b/tests/Database/Context.transaction.phpt
@@ -28,5 +28,5 @@ test(function () use ($context) {
 	$context->query('DELETE FROM book');
 	$context->commit();
 
-	Assert::false($context->fetchField('SELECT id FROM book WHERE id = ', 3));
+	Assert::null($context->fetchField('SELECT id FROM book WHERE id = ', 3));
 });

--- a/tests/Database/ResultSet.fetch().phpt
+++ b/tests/Database/ResultSet.fetch().phpt
@@ -76,3 +76,10 @@ test(function () use ($context, $driverName) {
 		$res->fetch();
 	}, E_USER_NOTICE, $message);
 });
+
+
+test(function () use ($context, $driverName) {
+	$res = $context->query('SELECT id FROM author WHERE id = ?', 666);
+
+	Assert::null($res->fetch());
+});

--- a/tests/Database/ResultSet.fetchField().phpt
+++ b/tests/Database/ResultSet.fetchField().phpt
@@ -21,3 +21,10 @@ test(function () use ($context) {
 	Assert::same(12, $res->fetchField(1));
 	Assert::same('Geek', $res->fetchField('name'));
 });
+
+
+test(function () use ($context) {
+	$res = $context->query('SELECT id FROM author WHERE id = ?', 666);
+
+	Assert::null($res->fetchField());
+});

--- a/tests/Database/Table/Selection.fetch().phpt
+++ b/tests/Database/Table/Selection.fetch().phpt
@@ -22,4 +22,5 @@ test(function () use ($context) {
 	}
 
 	Assert::same(['PHP'], $tags);
+	Assert::null($context->table('book')->where('title', 'Nonexistent')->fetch());
 });

--- a/tests/Database/Table/Selection.fetchField().phpt
+++ b/tests/Database/Table/Selection.fetchField().phpt
@@ -17,10 +17,12 @@ Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverN
 test(function () use ($context) {
 	$title = $context->table('book')->where('id', 1)->fetchField('title');  // SELECT `title` FROM `book` WHERE `id` = 1
 	Assert::same('1001 tipu a triku pro PHP', $title);
+	Assert::null($context->table('book')->where('title', 'Nonexistent')->fetchField());
 });
 
 
 test(function () use ($context) {
 	$title = $context->table('book')->where('id', 1)->select('title')->fetchField();  // SELECT `title` FROM `book` WHERE `id` = 1
 	Assert::same('1001 tipu a triku pro PHP', $title);
+	Assert::null($context->table('book')->where('title', 'Nonexistent')->select('title')->fetchField());
 });

--- a/tests/Database/Table/Table.related().phpt
+++ b/tests/Database/Table/Table.related().phpt
@@ -92,7 +92,7 @@ test(function () use ($context) {
 	$author = $context->table('author')->get(11);
 	$books  = $author->related('book')->where('translator_id', 11);
 	Assert::same('1001 tipu a triku pro PHP', $books->fetch()->title);
-	Assert::false($books->fetch());
+	Assert::null($books->fetch());
 
 	Assert::same('1001 tipu a triku pro PHP', $author->related('book')->fetch()->title);
 


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? yes

Since this is v3.0, I believe it's time to fix this old issue. It would be more logical if `fetch()` and `fetchField()` methods returned `NULL` instead of `FALSE`.

Why? If you have for example form factory with `create()` method with optinal parameter:
```php
class FormFactory
{
    public function create(IRow $row = NULL) {}
}
```
Now you need to distinguish result from `fetch()` method like this:
```php
$this->formFactory->create($repository->fetch() ?: NULL);
```
After this change, result of `fetch()` could be passed directly to similar methods.

I also added `fetchField()` method to `IRowContainer`.