### PR TITLE
SqliteDriver::getColumns() fix regexp for autoincrement recognition [Closes #164]

### DIFF
--- a/src/Database/Drivers/SqliteDriver.php
+++ b/src/Database/Drivers/SqliteDriver.php
@@ -179,7 +179,7 @@ class SqliteDriver implements Nette\Database\ISupplementalDriver
 		$columns = [];
 		foreach ($this->connection->query("PRAGMA table_info({$this->delimite($table)})") as $row) {
 			$column = $row['name'];
-			$pattern = "/(\"$column\"|\[$column\]|$column)\\s+[^,]+\\s+PRIMARY\\s+KEY\\s+AUTOINCREMENT/Ui";
+			$pattern = "/(\"$column\"|`$column`|\[$column\]|$column)\\s+[^,]+\\s+PRIMARY\\s+KEY\\s+AUTOINCREMENT/Ui";
 			$type = explode('(', $row['type']);
 			$columns[] = [
 				'name' => $column,


### PR DESCRIPTION
- bug fix? Closes #164
- new feature? no
- BC break? no

Just fix the regular expression for finding autoincrement column in SQLite table.

I don't know if this is only SQLite 3.11.0 issue, but it uses "`" as quote character for column and table names, so autoincrement column definition looks like this:

`id` INTEGER NULL PRIMARY KEY AUTOINCREMENT
