### PR TITLE
* Fixed an error in converting foreign key values to integers

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -905,12 +905,12 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 				}
 
 				$key = $row[$column];
-				$cacheKeys[$key] = TRUE;
+				$cacheKeys[] = $key;
 			}
 
 			if ($cacheKeys) {
 				$selection = $this->createSelectionInstance($table);
-				$selection->where($selection->getPrimary(), array_keys($cacheKeys));
+				$selection->where($selection->getPrimary(), $cacheKeys);
 			} else {
 				$selection = [];
 			}


### PR DESCRIPTION
- bug fix? yes   <!-- #issue numbers, if any -->
- new feature? no
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->

An issue of auto-convert of row values used as foreign keys to integers (by PHP). The values were used in cacheKeys as array keys, so they got converted by PHP. It is clearly wrong. This request changes the storage of row values to array values.