### PR TITLE
Support UPDATE with ORDER BY

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -120,6 +120,11 @@ class SqlBuilder
 	public function buildUpdateQuery(): string
 	{
 		$query = "UPDATE {$this->delimitedTable} SET ?set" . $this->tryDelimite($this->buildConditions());
+		
+		if ($this->order !== []) {
+			$query .= ' ORDER BY ' . implode(', ', $this->order);
+		}
+		
 		if ($this->limit !== null || $this->offset) {
 			$this->driver->applyLimit($query, $this->limit, $this->offset);
 		}


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: later if accepted

Hi,
this PR adds support for UPDATE with ORDER BY.
This is good when you have sequnce column and you want to increment tail values in this column.
SQL for this action:
```sql
UPDATE myTable SET sort_order = sort_order + 1 WHERE sort_order > 100 ORDER BY sort_order DESC
```
Current approach is to write own query, as stated above.

WIP: I will add test and doc for this.