### PR TITLE
SqlBuilder: sort all tables in parseJoinConditions (#181)

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -540,7 +540,7 @@ class SqlBuilder
 		}
 		$this->parameters['joinConditionSorted'] = [];
 		if (count($joinConditions)) {
-			while (reset($tableJoins)) {
+			while (reset($tableJoins) !== false) {
 				$this->getSortedJoins(key($tableJoins), $leftJoinDependency, $tableJoins, $joins);
 			}
 		}


### PR DESCRIPTION
- bug fix? yes  #181 
- new feature? no
- BC break? no

<!--
If you have multiple joins and second join have condition, you get InvalidArgumentException because parameter from second join is missing.
-->