### PR TITLE
ResultSet::normalizeRow(): fixed test when Postgre default TZ is not UTC

### DIFF
--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -129,7 +129,7 @@ class ResultSet implements \Iterator, IRowContainer
 	public function normalizeRow(array $row): array
 	{
 		if ($this->types === null) {
-			$this->types = (array) $this->connection->getSupplementalDriver()->getColumnTypes($this->pdoStatement);
+			$this->types = $this->connection->getSupplementalDriver()->getColumnTypes($this->pdoStatement);
 		}
 
 		foreach ($this->types as $key => $type) {

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -552,7 +552,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 		foreach ($result->getPdoStatement() as $key => $row) {
 			$row = $this->createRow($result->normalizeRow($row));
 			$primary = $row->getSignature(false);
-			$usedPrimary = $usedPrimary && (string) $primary !== '';
+			$usedPrimary = $usedPrimary && $primary !== '';
 			$this->rows[$usedPrimary ? $primary : $key] = $row;
 		}
 		$this->data = $this->rows;

--- a/tests/Database/ResultSet.normalizeRow.postgre.phpt
+++ b/tests/Database/ResultSet.normalizeRow.postgre.phpt
@@ -15,6 +15,8 @@ require __DIR__ . '/connect.inc.php'; // create $connection
 Nette\Database\Helpers::loadFromFile($connection, __DIR__ . '/files/pgsql-nette_test3.sql');
 
 
+$connection->query("SET TIMEZONE TO 'UTC'");
+
 $res = $connection->query('SELECT * FROM types');
 
 $row = $res->fetch();


### PR DESCRIPTION
Postgre returns timestamps with timezone according to timezone currently
set for connection. If timezone for connection is not set, it uses default
timezone which can differ between systems.

- bug fix? yes
- new feature? no
- BC break? no
