### PR TITLE
MySqlDriver: used query parameters in initialize

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -71,8 +71,8 @@ class Connection
 			? 'Nette\Database\Drivers\\' . ucfirst(str_replace('sql', 'Sql', $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME))) . 'Driver'
 			: $this->options['driverClass'];
 		$this->driver = new $class;
-		$this->driver->initialize($this, $this->options);
 		$this->preprocessor = new SqlPreprocessor($this);
+		$this->driver->initialize($this, $this->options);
 		$this->onConnect($this);
 	}
 

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -39,10 +39,10 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 		$charset = $options['charset']
 			?? (version_compare($connection->getPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION), '5.5.3', '>=') ? 'utf8mb4' : 'utf8');
 		if ($charset) {
-			$connection->query("SET NAMES '$charset'");
+			$connection->query('SET NAMES ?', $charset);
 		}
 		if (isset($options['sqlmode'])) {
-			$connection->query("SET sql_mode='$options[sqlmode]'");
+			$connection->query('SET sql_mode=?', $options['sqlmode']);
 		}
 	}
 


### PR DESCRIPTION
Used query parameters instead of string concatenation of statement and parameters.