### PR TITLE
PHP 7.2 fixed parameter passed to count

### DIFF
--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -157,6 +157,7 @@ class GroupedSelection extends Selection
 			$this->accessColumn($this->column);
 			foreach ((array) $this->rows as $key => $row) {
 				$ref = &$data[$row[$this->column]];
+				$ref = is_null($ref) ? [] : $ref;
 				$skip = &$offset[$row[$this->column]];
 				if ($limit === null || $rows <= 1 || (count($ref) < $limit && $skip >= $this->sqlBuilder->getOffset())) {
 					$ref[$key] = $row;

--- a/src/Database/Table/GroupedSelection.php
+++ b/src/Database/Table/GroupedSelection.php
@@ -157,9 +157,8 @@ class GroupedSelection extends Selection
 			$this->accessColumn($this->column);
 			foreach ((array) $this->rows as $key => $row) {
 				$ref = &$data[$row[$this->column]];
-				$ref = is_null($ref) ? [] : $ref;
 				$skip = &$offset[$row[$this->column]];
-				if ($limit === null || $rows <= 1 || (count($ref) < $limit && $skip >= $this->sqlBuilder->getOffset())) {
+				if ($limit === null || $rows <= 1 || (count($ref ?? []) < $limit && $skip >= $this->sqlBuilder->getOffset())) {
 					$ref[$key] = $row;
 				} else {
 					unset($this->rows[$key]);


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

The $ref variable could have null value and in PHP 7.2 parameter in count can only be an array or an object implements Countable