### PR TITLE
adding possibility to read fraction of seconds to DateInterval instan…

### DIFF
--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -178,7 +178,9 @@ class ResultSet implements \Iterator, IRowContainer
 			} elseif ($type === IStructure::FIELD_TIME_INTERVAL) {
 				preg_match('#^(-?)(\d+)\D(\d+)\D(\d+)(.\d+)?\z#', $value, $m);
 				$row[$key] = new \DateInterval("PT$m[2]H$m[3]M$m[4]S");
-				$row[$key]->f = (empty($m[5]) ? 0 : floatval($m[5]));
+				if (PHP_VERSION_ID >= 70100) {
+					$row[$key]->f = (empty($m[5]) ? 0 : floatval($m[5]));
+				}
 				$row[$key]->invert = (int) (bool) $m[1];
 
 			} elseif ($type === IStructure::FIELD_UNIX_TIMESTAMP) {

--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -176,8 +176,9 @@ class ResultSet implements \Iterator, IRowContainer
 				$row[$key] = new Nette\Utils\DateTime($value);
 
 			} elseif ($type === IStructure::FIELD_TIME_INTERVAL) {
-				preg_match('#^(-?)(\d+)\D(\d+)\D(\d+)\z#', $value, $m);
+				preg_match('#^(-?)(\d+)\D(\d+)\D(\d+)(.\d+)?\z#', $value, $m);
 				$row[$key] = new \DateInterval("PT$m[2]H$m[3]M$m[4]S");
+				$row[$key]->f = (empty($m[5]) ? 0 : floatval($m[5]));
 				$row[$key]->invert = (int) (bool) $m[1];
 
 			} elseif ($type === IStructure::FIELD_UNIX_TIMESTAMP) {

--- a/tests/Database/ResultSet.normalizeRow.mysql.phpt
+++ b/tests/Database/ResultSet.normalizeRow.mysql.phpt
@@ -13,6 +13,19 @@ require __DIR__ . '/connect.inc.php'; // create $connection
 Nette\Database\Helpers::loadFromFile($connection, __DIR__ . '/files/mysql-nette_test3.sql');
 
 
+
+$avgRes = $connection->query('SELECT sec_to_time(avg(time_to_sec(`time`))) AS `avg_time` FROM `avgs`');
+
+$avgTime = new DateInterval('PT10H10M10S');
+$avgTime->f = 0.7500;
+
+Assert::equal([
+	'avg_time' => $avgTime
+	], (array) $avgRes->fetch());
+
+
+	
+	
 $res = $connection->query('SELECT * FROM types');
 
 Assert::equal([

--- a/tests/Database/ResultSet.normalizeRow.mysql.phpt
+++ b/tests/Database/ResultSet.normalizeRow.mysql.phpt
@@ -13,17 +13,18 @@ require __DIR__ . '/connect.inc.php'; // create $connection
 Nette\Database\Helpers::loadFromFile($connection, __DIR__ . '/files/mysql-nette_test3.sql');
 
 
+if (PHP_VERSION_ID >= 70100) {
 
-$avgRes = $connection->query('SELECT sec_to_time(avg(time_to_sec(`time`))) AS `avg_time` FROM `avgs`');
+	$avgRes = $connection->query('SELECT sec_to_time(avg(time_to_sec(`time`))) AS `avg_time` FROM `avgs`');
 
-$avgTime = new DateInterval('PT10H10M10S');
-$avgTime->f = 0.7500;
+	$avgTime = new DateInterval('PT10H10M10S');
+	$avgTime->f = 0.7500;
 
-Assert::equal([
-	'avg_time' => $avgTime
-	], (array) $avgRes->fetch());
+	Assert::equal([
+		'avg_time' => $avgTime
+		], (array) $avgRes->fetch());
 
-
+}
 	
 	
 $res = $connection->query('SELECT * FROM types');

--- a/tests/Database/Structure.phpt
+++ b/tests/Database/Structure.phpt
@@ -24,7 +24,7 @@ class StructureMock extends Structure
 
 
 /**
- * @testCase
+ * @TestCase
  */
 class StructureTestCase extends TestCase
 {

--- a/tests/Database/files/mysql-nette_test3.sql
+++ b/tests/Database/files/mysql-nette_test3.sql
@@ -38,3 +38,13 @@ INSERT INTO `types` (`unsigned_int`, `int`, `smallint`, `tinyint`, `mediumint`, 
 (1,	1,	1,	1,	1,	1,	1,	1,	1.1,	1,	1.1,	'2012-10-13',	'30:10:10',	'2012-10-13 10:10:10',	'2012-10-13 10:10:10',	'2012',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a',	'a'),
 (0,	0,	0,	0,	0,	0,	0,	0,	0.5,	0.5,	0.5,	'0000-00-00',	'00:00:00',	'0000-00-00 00:00:00',	'0000-00-00 00:00:00',	'2000',	'',	'',	'\0',	'',	'',	'',	'',	'',	'',	'',	'',	'',	'b',	''),
 (NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL,	NULL);
+
+CREATE TEMPORARY TABLE `avgs` (
+  `time` time
+) ENGINE=InnoDB;
+
+INSERT INTO `avgs` (`time`) VALUES
+('10:10:12'),
+('10:10:11'),
+('10:10:10'),
+('10:10:10');


### PR DESCRIPTION
Possibility of fraction of seconds to be readable from database by ActiveRow interface was added. Appropriate preg_match in Database/ResultSet.php was adjusted and resulting DateInterval class instance filled with fraction of second (if any). Unit test with MySQL was altered accordingly.

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
