### PR TITLE
MySqlDriver: Fix PDO::ATTR_CASE

### DIFF
--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -138,7 +138,6 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 				'table' => $table,
 				'nativetype' => strtoupper($type[0]),
 				'size' => isset($type[1]) ? (int) $type[1] : null,
-				'unsigned' => (bool) strstr($row['type'], 'unsigned'),
 				'nullable' => $row['null'] === 'YES',
 				'default' => $row['default'],
 				'autoincrement' => $row['extra'] === 'auto_increment',

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -131,20 +131,20 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$columns = [];
 		foreach ($this->connection->query('SHOW FULL COLUMNS FROM ' . $this->delimite($table)) as $row) {
-            $row=array_change_key_case((array) $row, CASE_LOWER);
-            $type = explode('(', $row['type']);
-            $columns[] = [
-                'name' => $row['field'],
-                'table' => $table,
-                'nativetype' => strtoupper($type[0]),
-                'size' => isset($type[1]) ? (int) $type[1] : null,
-                'unsigned' => (bool) strstr($row['type'], 'unsigned'),
-                'nullable' => $row['null'] === 'YES',
-                'default' => $row['default'],
-                'autoincrement' => $row['extra'] === 'auto_increment',
-                'primary' => $row['key'] === 'PRI',
-                'vendor' => (array) $row,
-            ];
+			$row=array_change_key_case((array) $row, CASE_LOWER);
+			$type = explode('(', $row['type']);
+			$columns[] = [
+				'name' => $row['field'],
+				'table' => $table,
+				'nativetype' => strtoupper($type[0]),
+				'size' => isset($type[1]) ? (int) $type[1] : null,
+				'unsigned' => (bool) strstr($row['type'], 'unsigned'),
+				'nullable' => $row['null'] === 'YES',
+				'default' => $row['default'],
+				'autoincrement' => $row['extra'] === 'auto_increment',
+				'primary' => $row['key'] === 'PRI',
+				'vendor' => (array) $row,
+			];
 		}
 		return $columns;
 	}
@@ -154,7 +154,7 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$indexes = [];
 		foreach ($this->connection->query('SHOW INDEX FROM ' . $this->delimite($table)) as $row) {
-            $row=array_change_key_case((array) $row, CASE_LOWER);
+			$row=array_change_key_case((array) $row, CASE_LOWER);
 			$indexes[$row['key_name']]['name'] = $row['key_name'];
 			$indexes[$row['key_name']]['unique'] = !$row['non_unique'];
 			$indexes[$row['key_name']]['primary'] = $row['key_name'] === 'PRIMARY';
@@ -171,7 +171,7 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 			. 'WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL AND TABLE_NAME = ' . $this->connection->quote($table);
 
 		foreach ($this->connection->query($query) as $id => $row) {
-            $row=array_change_key_case((array) $row, CASE_LOWER);
+			$row=array_change_key_case((array) $row, CASE_LOWER);
 			$keys[$id]['name'] = $row['constraint_name']; // foreign key name
 			$keys[$id]['local'] = $row['column_name']; // local columns
 			$keys[$id]['table'] = $row['referenced_table_name']; // referenced table

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -131,18 +131,20 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$columns = [];
 		foreach ($this->connection->query('SHOW FULL COLUMNS FROM ' . $this->delimite($table)) as $row) {
-			$type = explode('(', $row['Type']);
-			$columns[] = [
-				'name' => $row['Field'],
-				'table' => $table,
-				'nativetype' => strtoupper($type[0]),
-				'size' => isset($type[1]) ? (int) $type[1] : null,
-				'nullable' => $row['Null'] === 'YES',
-				'default' => $row['Default'],
-				'autoincrement' => $row['Extra'] === 'auto_increment',
-				'primary' => $row['Key'] === 'PRI',
-				'vendor' => (array) $row,
-			];
+            $row=array_change_key_case((array) $row, CASE_LOWER);
+            $type = explode('(', $row['type']);
+            $columns[] = [
+                'name' => $row['field'],
+                'table' => $table,
+                'nativetype' => strtoupper($type[0]),
+                'size' => isset($type[1]) ? (int) $type[1] : null,
+                'unsigned' => (bool) strstr($row['type'], 'unsigned'),
+                'nullable' => $row['null'] === 'YES',
+                'default' => $row['default'],
+                'autoincrement' => $row['extra'] === 'auto_increment',
+                'primary' => $row['key'] === 'PRI',
+                'vendor' => (array) $row,
+            ];
 		}
 		return $columns;
 	}
@@ -152,10 +154,11 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$indexes = [];
 		foreach ($this->connection->query('SHOW INDEX FROM ' . $this->delimite($table)) as $row) {
-			$indexes[$row['Key_name']]['name'] = $row['Key_name'];
-			$indexes[$row['Key_name']]['unique'] = !$row['Non_unique'];
-			$indexes[$row['Key_name']]['primary'] = $row['Key_name'] === 'PRIMARY';
-			$indexes[$row['Key_name']]['columns'][$row['Seq_in_index'] - 1] = $row['Column_name'];
+            $row=array_change_key_case((array) $row, CASE_LOWER);
+			$indexes[$row['key_name']]['name'] = $row['key_name'];
+			$indexes[$row['key_name']]['unique'] = !$row['non_unique'];
+			$indexes[$row['key_name']]['primary'] = $row['key_name'] === 'PRIMARY';
+			$indexes[$row['key_name']]['columns'][$row['seq_in_index'] - 1] = $row['column_name'];
 		}
 		return array_values($indexes);
 	}
@@ -168,10 +171,11 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 			. 'WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL AND TABLE_NAME = ' . $this->connection->quote($table);
 
 		foreach ($this->connection->query($query) as $id => $row) {
-			$keys[$id]['name'] = $row['CONSTRAINT_NAME']; // foreign key name
-			$keys[$id]['local'] = $row['COLUMN_NAME']; // local columns
-			$keys[$id]['table'] = $row['REFERENCED_TABLE_NAME']; // referenced table
-			$keys[$id]['foreign'] = $row['REFERENCED_COLUMN_NAME']; // referenced columns
+            $row=array_change_key_case((array) $row, CASE_LOWER);
+			$keys[$id]['name'] = $row['constraint_name']; // foreign key name
+			$keys[$id]['local'] = $row['column_name']; // local columns
+			$keys[$id]['table'] = $row['referenced_table_name']; // referenced table
+			$keys[$id]['foreign'] = $row['referenced_column_name']; // referenced columns
 		}
 
 		return array_values($keys);

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -131,7 +131,7 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$columns = [];
 		foreach ($this->connection->query('SHOW FULL COLUMNS FROM ' . $this->delimite($table)) as $row) {
-			$row=array_change_key_case((array) $row, CASE_LOWER);
+			$row = array_change_key_case((array) $row, CASE_LOWER);
 			$type = explode('(', $row['type']);
 			$columns[] = [
 				'name' => $row['field'],
@@ -153,7 +153,7 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	{
 		$indexes = [];
 		foreach ($this->connection->query('SHOW INDEX FROM ' . $this->delimite($table)) as $row) {
-			$row=array_change_key_case((array) $row, CASE_LOWER);
+			$row = array_change_key_case((array) $row, CASE_LOWER);
 			$indexes[$row['key_name']]['name'] = $row['key_name'];
 			$indexes[$row['key_name']]['unique'] = !$row['non_unique'];
 			$indexes[$row['key_name']]['primary'] = $row['key_name'] === 'PRIMARY';
@@ -170,7 +170,7 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 			. 'WHERE TABLE_SCHEMA = DATABASE() AND REFERENCED_TABLE_NAME IS NOT NULL AND TABLE_NAME = ' . $this->connection->quote($table);
 
 		foreach ($this->connection->query($query) as $id => $row) {
-			$row=array_change_key_case((array) $row, CASE_LOWER);
+			$row = array_change_key_case((array) $row, CASE_LOWER);
 			$keys[$id]['name'] = $row['constraint_name']; // foreign key name
 			$keys[$id]['local'] = $row['column_name']; // local columns
 			$keys[$id]['table'] = $row['referenced_table_name']; // referenced table


### PR DESCRIPTION
- bug fix? yes
- BC break? no

When you used PDO::ATTR_CASE option for MySQL connection Exception was thrown: Cannot read an undeclared column. Fix includes functions `getColumns(string $table)`, `getIndexes(string $table)`, `getForeignKeys(string $table)`