### PR TITLE
Revert removing of `formatBool()`

### DIFF
--- a/src/Database/Drivers/MsSqlDriver.php
+++ b/src/Database/Drivers/MsSqlDriver.php
@@ -40,6 +40,12 @@ class MsSqlDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format("'Y-m-d H:i:s'");

--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -78,6 +78,12 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format("'Y-m-d H:i:s'");

--- a/src/Database/Drivers/OciDriver.php
+++ b/src/Database/Drivers/OciDriver.php
@@ -61,6 +61,12 @@ class OciDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format($this->fmtDateTime);

--- a/src/Database/Drivers/OdbcDriver.php
+++ b/src/Database/Drivers/OdbcDriver.php
@@ -39,6 +39,12 @@ class OdbcDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format('#m/d/Y H:i:s#');

--- a/src/Database/Drivers/PgSqlDriver.php
+++ b/src/Database/Drivers/PgSqlDriver.php
@@ -63,6 +63,12 @@ class PgSqlDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? 'TRUE' : 'FALSE';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format("'Y-m-d H:i:s'");

--- a/src/Database/Drivers/SqliteDriver.php
+++ b/src/Database/Drivers/SqliteDriver.php
@@ -74,6 +74,12 @@ class SqliteDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		return $value->format($this->fmtDateTime);

--- a/src/Database/Drivers/SqlsrvDriver.php
+++ b/src/Database/Drivers/SqlsrvDriver.php
@@ -49,6 +49,12 @@ class SqlsrvDriver implements Nette\Database\ISupplementalDriver
 	}
 
 
+	public function formatBool(bool $value): string
+	{
+		return $value ? '1' : '0';
+	}
+
+
 	public function formatDateTime(\DateTimeInterface $value): string
 	{
 		/** @see https://msdn.microsoft.com/en-us/library/ms187819.aspx */

--- a/src/Database/ISupplementalDriver.php
+++ b/src/Database/ISupplementalDriver.php
@@ -39,6 +39,11 @@ interface ISupplementalDriver
 	function delimite(string $name): string;
 
 	/**
+	 * Formats boolean for use in a SQL statement.
+	 */
+	function formatBool(bool $value): string;
+
+	/**
 	 * Formats date-time for use in a SQL statement.
 	 */
 	function formatDateTime(\DateTimeInterface $value): string;


### PR DESCRIPTION
- bug fix: see commit e662ef6581c79bb279b6874423828f80678158e6
- BC break? no
- doc PR: no, just internal
- tests: no, only revert, no other `format*` methods covered too.

At Feb 2017 (1½ year ago) is removed the `formatBool()` from `ISupplementalDriver` interface. But it is make BC break for external libs like a [`nextras/migrations`](https://github.com/nextras/migrations/blob/f0ce88860ed223ec29da6a19796fcc7807cad1fe/src/Bridges/NetteDatabase/NetteAdapter.php#L57-L60). See [comments bellow diff](https://github.com/nette/database/commit/e662ef6581c79bb279b6874423828f80678158e6#comments).

Currently is `nette/database` as `dbal` in `nextras/migrations` completely unusable.

Probably is possible to fix this issue on depending project, but this way looks most clean for me. I see `fotmatBool()` useful, I vote to keep it. Or is anywhere in `nette/database` replacement?

Note: Changes from future commit bd9bfcc598f285751b99a1703521a6f8a9771e8a applied.