### PR TITLE
Selection::current return row or false

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -934,7 +934,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	}
 
 
-	/** @return ActiveRow|bool */
+	/** @return ActiveRow|false */
 	public function current()
 	{
 		if (($key = current($this->keys)) !== false) {


### PR DESCRIPTION
- bug fix / new feature?
- BC break? no

Selection::current changed from `bool|ActiveRow` to specifier `false|ActiveRow`
