### PR TITLE
Fixed Selection::insert spoiling PDO:lastInsertId

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -739,6 +739,10 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	 */
 	public function insert(iterable $data)
 	{
+		//should be called before query for not to spoil PDO::lastInsertId
+		$primarySequenceName = $this->getPrimarySequence();
+		$primaryAutoincrementKey = $this->context->getStructure()->getPrimaryAutoincrementKey($this->name);
+
 		if ($data instanceof self) {
 			$return = $this->context->queryArgs($this->sqlBuilder->buildInsertQuery() . ' ' . $data->getSql(), $data->getSqlBuilder()->getParameters());
 
@@ -755,9 +759,6 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 			$this->refCache->unsetReferencing($this->cache->getGeneralCacheKey(), $this->cache->getSpecificCacheKey());
 			return $return->getRowCount();
 		}
-
-		$primarySequenceName = $this->getPrimarySequence();
-		$primaryAutoincrementKey = $this->context->getStructure()->getPrimaryAutoincrementKey($this->name);
 
 		$primaryKey = [];
 		foreach ((array) $this->primary as $key) {

--- a/tests/Database/Table/bugs/bug216.phpt
+++ b/tests/Database/Table/bugs/bug216.phpt
@@ -1,9 +1,11 @@
 <?php
 
 /**
- * Test: Nette\Database\Table\Selection: Insert operations
+ * Test: bug #216
  * @dataProvider? ../databases.ini
  */
+
+declare(strict_types=1);
 
 use Tester\Assert;
 

--- a/tests/Database/Table/bugs/bug216.phpt
+++ b/tests/Database/Table/bugs/bug216.phpt
@@ -44,4 +44,3 @@ $book = $context->table('author')->insert([
 Assert::type(Nette\Database\Table\ActiveRow::class, $book);
 Assert::equal('eddard stark', $book->name);
 Assert::equal(new Nette\Utils\DateTime('2011-11-11'), $book->born);
-

--- a/tests/Database/Table/bugs/bug216.phpt
+++ b/tests/Database/Table/bugs/bug216.phpt
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test: Nette\Database\Table\Selection: Insert operations
+ * @dataProvider? ../databases.ini
+ */
+
+use Tester\Assert;
+
+require __DIR__ . '/../../../bootstrap.php';
+
+//Prepare connection
+$options = Tester\Environment::loadData() + ['user' => null, 'password' => null];
+
+try {
+	$connection = new Nette\Database\Connection($options['dsn'], $options['user'], $options['password']);
+} catch (PDOException $e) {
+	Tester\Environment::skip("Connection to '$options[dsn]' failed. Reason: " . $e->getMessage());
+}
+
+if (strpos($options['dsn'], 'sqlite::memory:') === false) {
+	Tester\Environment::lock($options['dsn'], TEMP_DIR);
+}
+
+$driverName = $connection->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
+$cacheMemoryStorage = new Nette\Caching\Storages\MemoryStorage;
+
+$structure = new Nette\Database\Structure($connection, $cacheMemoryStorage);
+$conventions = new Nette\Database\Conventions\StaticConventions();
+$context = new Nette\Database\Context($connection, $structure, $conventions, $cacheMemoryStorage);
+
+//Testing
+Nette\Database\Helpers::loadFromFile($connection, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
+
+$book = $context->table('author')->insert([
+	'name' => $context->literal('LOWER(?)', 'Eddard Stark'),
+	'web' => 'http://example.com',
+	'born' => new \DateTime('2011-11-11'),
+]);  // INSERT INTO `author` (`name`, `web`) VALUES (LOWER('Eddard Stark'), 'http://example.com', '2011-11-11 00:00:00')
+// id = 14
+
+Assert::type(Nette\Database\Table\ActiveRow::class, $book);
+Assert::equal('eddard stark', $book->name);
+Assert::equal(new Nette\Utils\DateTime('2011-11-11'), $book->born);
+


### PR DESCRIPTION
- bug fix #216 
- BC break? no

Changes the order of method calls in Selection::insert, so that getPrimarySequence and getPrimaryAutoincrementKey methods are called before actual query. Without this edit calling of these methods can spoil PDO:lastInsertId by database query for building Structure cache, which results in not obtaining new inserted ActiveRow.
This fail usualy happened on first insert query when used with StaticConvetions.