### PR TITLE
Connection: added inTransaction()

### DIFF
--- a/src/Database/Connection.php
+++ b/src/Database/Connection.php
@@ -152,6 +152,12 @@ class Connection
 	}
 
 
+	public function inTransaction(): bool
+	{
+		return $this->pdo && $this->pdo->inTransaction();
+	}
+
+
 	/**
 	 * Generates and executes SQL query.
 	 */


### PR DESCRIPTION
A new `inTransaction()` method might be a very useful shortcut.

Calling is unnecessary long right now.
```php
/* @var \Nette\Database\Connection $db */
if ($db->getPdo()->inTransaction()) {
   $db->rollBack();
}
```

Why not just use it like this?
```php
/* @var \Nette\Database\Connection $db */
if ($db->inTransaction()) {
   $db->rollBack();
}
```

Other shortcuts like `beginTransaction()`, `commit()` and `rollback()` are already implemented in `Connection` class.