### PR TITLE
SqlBuilder: Fixed loading arguments for left join conditions

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -585,6 +585,9 @@ class SqlBuilder
 			}
 			$finalJoins += $tableJoins[$table];
 			$key = isset($this->aliases[$table]) ? $table : $this->reservedTableNames[$table];
+			if ($key[0] === '.') {
+				$key = substr($key, 1);
+			}
 			$this->parameters['joinConditionSorted'] += isset($this->parameters['joinCondition'][$key])
 				? [$table => $this->parameters['joinCondition'][$key]]
 				: [];

--- a/tests/Database/Table/SqlBuilder.parseJoinConditions().phpt
+++ b/tests/Database/Table/SqlBuilder.parseJoinConditions().phpt
@@ -89,3 +89,10 @@ test(function () use ($context, $driver) {
 	}
 	Assert::same([2, 'private'], $sqlBuilder->getParameters());
 });
+
+test(function () use ($context) {
+	$sqlBuilder = new SqlBuilderMock('book', $context);
+	$sqlBuilder->addJoinCondition('next_volume.author', 'next_volume.author.born >', '2000-01-01');
+
+	Assert::same(['2000-01-01'], $sqlBuilder->getParameters());
+});


### PR DESCRIPTION
- bug fix
- BC break? no

Fixed loading arguments for left join conditions specified for referencing tables (before this pull reguest it loads arguments correctly only for related tables)