### PR TITLE
Implement SQL Clause in Where IS NOT NULL

### DIFF
--- a/src/Database/SqlPreprocessor.php
+++ b/src/Database/SqlPreprocessor.php
@@ -242,7 +242,21 @@ class SqlPreprocessor
 						}
 					} else {
 						$v = $this->formatValue($v);
-						$vx[] = $k . ' ' . ($operator ?: ($v === 'NULL' ? 'IS' : '=')) . ' ' . $v;
+						// Allow usage of IS NULL
+						// Call 
+						// 'database_field' => NULL, 
+						// Will represent database_field IS NULL
+						if ($operator) {
+						    if (($operator === 'NOT') && ($v === 'NULL')) {
+							$operation = 'IS NOT';
+						    }
+						} elseif ($v === 'NULL') {
+						    $operation = 'IS';
+						} else {
+						    $operation = '=';
+						}
+						$vx[] = $k . ' ' . $operation . ' ' . $v;
+						
 					}
 				}
 				return $value ? '(' . implode(') ' . strtoupper($mode) . ' (', $vx) . ')' : '1=1';


### PR DESCRIPTION
Allow usage of IS NULL
Passing arguments on array like
 'database_field' => NULL, 

Will represent SQL query 
`database_field` IS NULL

- new feature
- BC break? no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Allow passing NULL value to where clauses in queries

Using 
'database_field NOT' => null,
'database_field'       => null,


Will create query
database_field IS NOT NULL 
database_field IS NULL
-->
