### PR TITLE
ResultSet: only format strings as floats

### DIFF
--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -140,7 +140,7 @@ class ResultSet implements \Iterator, IRowContainer
 				$row[$key] = is_float($tmp = $value * 1) ? $value : $tmp;
 
 			} elseif ($type === IStructure::FIELD_FLOAT) {
-				if (($pos = strpos($value, '.')) !== false) {
+				if (is_string($value) && ($pos = strpos($value, '.')) !== false) {
 					$value = rtrim(rtrim($pos === 0 ? "0$value" : $value, '0'), '.');
 				}
 				$float = (float) $value;

--- a/tests/Database/ResultSet.normalizeRow.mysql.phpt
+++ b/tests/Database/ResultSet.normalizeRow.mysql.phpt
@@ -132,3 +132,16 @@ $avgTime->f = 0.5;
 Assert::equal([
 	'avg_time' => $avgTime,
 ], (array) $res->fetch());
+
+
+$connection->getPdo()->setAttribute(PDO::ATTR_EMULATE_PREPARES, false);
+
+$res = $connection->query('SELECT `int`, `decimal`, `decimal2`, `float`, `double` FROM types');
+
+Assert::equal([
+	'int' => 1,
+	'decimal' => 1.0,
+	'decimal2' => 1.1,
+	'float' => 1.0,
+	'double' => 1.1,
+], (array) $res->fetch());


### PR DESCRIPTION
Because with native prepared statements in MySQL, floats are returned as floats, not strings like with emulated prepares

- bug fix?  #227
- BC break? no
- doc PR: no

Fixes #227