### PR TITLE
Exception code property must be int - DriverException.php

### DIFF
--- a/src/Database/DriverException.php
+++ b/src/Database/DriverException.php
@@ -31,7 +31,7 @@ class DriverException extends \PDOException
 			$e->code = $m[1];
 		} else {
 			$e->errorInfo = $src->errorInfo;
-			$e->code = $src->code;
+			$e->code = (int) $src->code;
 		}
 		return $e;
 	}


### PR DESCRIPTION
As PHP exception is defined with code of type int, there must be always int

public function __construct(string $message = "", int $code = 0, \Throwable $previous = NULL) {}

- bug fix
- BC break? no