### PR TITLE
PDO, query with boolean parameters fails silently

### DIFF
--- a/src/Database/ResultSet.php
+++ b/src/Database/ResultSet.php
@@ -59,7 +59,7 @@ class ResultSet implements \Iterator, IRowContainer
 			if (substr($queryString, 0, 2) === '::') {
 				$connection->getPdo()->{substr($queryString, 2)}();
 			} elseif ($queryString !== null) {
-				static $types = ['boolean' => PDO::PARAM_BOOL, 'integer' => PDO::PARAM_INT,
+				static $types = ['boolean' => PDO::PARAM_INT, 'integer' => PDO::PARAM_INT,
 					'resource' => PDO::PARAM_LOB, 'NULL' => PDO::PARAM_NULL, ];
 				$this->pdoStatement = $connection->getPdo()->prepare($queryString);
 				foreach ($params as $key => $value) {


### PR DESCRIPTION
- bug fix
- BC break? most likely not

Work around an PHP bug, where mysql query with boolean parameters and disabled emulated prepare-statements fails silently. 
Bool value is interepreted incorrectly, more information in php bugtracker thread:

https://bugs.php.net/bug.php?id=38546

There is currently work being done in fixing the issue on the PHP end.