### PR TITLE
Fix for bug 170

### DIFF
--- a/tests/Database/Structure.phpt
+++ b/tests/Database/Structure.phpt
@@ -82,13 +82,13 @@ class StructureTestCase extends TestCase
 		$this->connection->shouldReceive('getSupplementalDriver')->times(4)->andReturn($this->driver);
 		$this->driver->shouldReceive('getForeignKeys')->with('authors')->once()->andReturn([]);
 		$this->driver->shouldReceive('getForeignKeys')->with('Books')->once()->andReturn([
-			['local' => 'author_id', 'table' => 'authors', 'foreign' => 'id'],
-			['local' => 'translator_id', 'table' => 'authors', 'foreign' => 'id'],
+			['local' => 'author_id', 'table' => 'authors', 'foreign' => 'id', 'name' => 'authors_fk1'],
+			['local' => 'translator_id', 'table' => 'authors', 'foreign' => 'id', 'name' => 'authors_fk2'],
 		]);
 		$this->driver->shouldReceive('getForeignKeys')->with('tags')->once()->andReturn([]);
 		$this->driver->shouldReceive('getForeignKeys')->with('books_x_tags')->once()->andReturn([
-			['local' => 'book_id', 'table' => 'Books', 'foreign' => 'id'],
-			['local' => 'tag_id', 'table' => 'tags', 'foreign' => 'id'],
+			['local' => 'book_id', 'table' => 'Books', 'foreign' => 'id', 'name' => 'books_x_tags_fk1'],
+			['local' => 'tag_id', 'table' => 'tags', 'foreign' => 'id', 'name' => 'books_x_tags_fk2'],
 		]);
 
 		$this->structure = new StructureMock($this->connection, $this->storage);

--- a/tests/Database/Structure.schemas.phpt
+++ b/tests/Database/Structure.schemas.phpt
@@ -68,8 +68,8 @@ class StructureSchemasTestCase extends TestCase
 		$this->connection->shouldReceive('getSupplementalDriver')->times(2)->andReturn($this->driver);
 		$this->driver->shouldReceive('getForeignKeys')->with('authors.authors')->once()->andReturn([]);
 		$this->driver->shouldReceive('getForeignKeys')->with('books.books')->once()->andReturn([
-			['local' => 'author_id', 'table' => 'authors.authors', 'foreign' => 'id'],
-			['local' => 'translator_id', 'table' => 'authors.authors', 'foreign' => 'id'],
+			['local' => 'author_id', 'table' => 'authors.authors', 'foreign' => 'id', 'name' => 'authors_authors_fk1'],
+			['local' => 'translator_id', 'table' => 'authors.authors', 'foreign' => 'id', 'name' => 'authors_authors_fk2'],
 		]);
 
 		$this->structure = new StructureMock($this->connection, $this->storage);


### PR DESCRIPTION
- bug fix: yes
- BC break: no (strictly yes - now foreign keys returned by driver should have name - all implementations of drivers in Nette have it that way, but some custom drivers could be problematic from that point of view)

This fixes bug #170.

The idea of that fix is that we can prefer FKs with less columns over FKs with more columns - this was exactly the point of #170.