### PR TITLE
Update param type in limit function

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -394,7 +394,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 	 * Sets limit clause, more calls rewrite old values.
 	 * @return static
 	 */
-	public function limit(int $limit, int $offset = null)
+	public function limit(?int $limit, int $offset = null)
 	{
 		$this->emptyResultSet();
 		$this->sqlBuilder->setLimit($limit, $offset);


### PR DESCRIPTION
bug fix

Oprava typu parametru u limit funkce, jelikož ne vždy chceme mít nějaký limit a pokud si napíšeme vrstvu na práci s datama, která může mít limit INT nebo NULL. Navíc uvnitř funkce se limit setuje a tam už null je null povolen.