### PR TITLE
Helpers: Fix dumpSql() for bool parameters

### DIFF
--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -137,9 +137,11 @@ class Helpers
 				return '<i' . (isset($info['uri']) ? ' title="' . htmlspecialchars($info['uri'], ENT_NOQUOTES, 'UTF-8') . '"' : null)
 					. '>&lt;' . htmlspecialchars($type, ENT_NOQUOTES, 'UTF-8') . ' resource&gt;</i> ';
 
-			} else {
-				return htmlspecialchars((string) $param, ENT_NOQUOTES, 'UTF-8');
+			} elseif (is_bool($param)) {
+				$param = (int) $param;
 			}
+
+			return htmlspecialchars((string) $param, ENT_NOQUOTES, 'UTF-8');
 		}, $sql);
 
 		return '<pre class="dump">' . trim($sql) . "</pre>\n";

--- a/tests/Database/Helpers.dumpSql.phpt
+++ b/tests/Database/Helpers.dumpSql.phpt
@@ -19,6 +19,11 @@ test(function () use ($connection) { // int check
 "<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> id = 10 <strong style=\"color:green\">OR</strong> id = 11</pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE id = ? OR id = ?', [10, 11], $connection));
 });
 
+test(function () use ($connection) { // bool check
+	Assert::same(
+"<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> deleted = 0</pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE deleted = ?', [false], $connection));
+});
+
 test(function () use ($connection) { // string check
 	Assert::same(
 "<pre class=\"dump\"><strong style=\"color:blue\">SELECT</strong> id \n<strong style=\"color:blue\">FROM</strong> author \n<strong style=\"color:blue\">WHERE</strong> name = <span title=\"Length 15 characters\">'Alexej Chruščev'</span></pre>\n", Nette\Database\Helpers::dumpSql('SELECT id FROM author WHERE name = ?', ['Alexej Chruščev'], $connection));


### PR DESCRIPTION
- bug fix
- BC break? no

This is just UI bug fix.
I found that `Helpers::dumpSql()` has problem with bool parameters.
Bool parameters are processed in last step and casted to `(string)`.
Problem is that `(string) FALSE` is empty string and not 0.
Because of that is `dumpSql()` able to generate invalid sql like this:
```
WHERE (`user`.`deleted` = OR `user`.`deleted` IS NULL)
```
instead of valid:
```
WHERE (`user`.`deleted` = 0 OR `user`.`deleted` IS NULL)
```
