### PR TITLE
ConnectionPanel: Added performance colors

### DIFF
--- a/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
+++ b/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
@@ -29,7 +29,7 @@ use Tracy\Helpers;
 			[$connection, $sql, $params, $source, $time, $rows, $error, $command, $explain] = $query;
 		?>
 		<tr>
-		<td style="background:rgba(255, 95, 23, <?= DbHelpers::queryPerformanceOpacity($time * 1000) ?>)">
+		<td style="background:rgba(255, 95, 23, <?= log($time * 1000 + 1, 10) * DbHelpers::$queryPerformanceScale ?>)">
 		<?php if ($error): ?>
 			<span title="<?= Helpers::escapeHtml($error) ?>">ERROR</span>
 		<?php elseif ($time !== null): echo sprintf('%0.3f', $time * 1000); endif ?>

--- a/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
+++ b/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
@@ -15,12 +15,6 @@ use Tracy\Helpers;
 	#tracy-debug td.nette-DbConnectionPanel-sql-insert { background: #E7ffE7 !important }
 	#tracy-debug td.nette-DbConnectionPanel-sql-delete { background: #FFE7E7 !important }
 	#tracy-debug td.nette-DbConnectionPanel-sql-update { background: #E7FBFF !important }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-500 { background: #f30808 !important; color: white }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-300 { background: #ff5f17 !important; color: white }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-150 { background: #fb834d !important; color: white }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-75 { background: #fb9567 !important; color: white }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-15 { background: #ffae89 !important; color: black }
-	#tracy-debug td.nette-DbConnectionPanel-queryTime-5 { background: #fbccb7 !important; color: black }
 </style>
 
 <h1 title="<?= Helpers::escapeHtml($connection->getDsn()) ?>">Queries: <?php
@@ -35,7 +29,7 @@ use Tracy\Helpers;
 			[$connection, $sql, $params, $source, $time, $rows, $error, $command, $explain] = $query;
 		?>
 		<tr>
-		<td<?= ($durationColor = DbHelpers::queryTimeClass($time * 1000)) !== null ? ' class="' . Helpers::escapeHtml('nette-DbConnectionPanel-queryTime-' . $durationColor) . '"' : '' ?>>
+		<td style="background:rgba(255, 95, 23, <?= DbHelpers::queryPerformanceOpacity($time * 1000) ?>)">
 		<?php if ($error): ?>
 			<span title="<?= Helpers::escapeHtml($error) ?>">ERROR</span>
 		<?php elseif ($time !== null): echo sprintf('%0.3f', $time * 1000); endif ?>

--- a/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
+++ b/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
@@ -15,6 +15,12 @@ use Tracy\Helpers;
 	#tracy-debug td.nette-DbConnectionPanel-sql-insert { background: #E7ffE7 !important }
 	#tracy-debug td.nette-DbConnectionPanel-sql-delete { background: #FFE7E7 !important }
 	#tracy-debug td.nette-DbConnectionPanel-sql-update { background: #E7FBFF !important }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-500 { background: #f30808 !important; color: white }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-300 { background: #ff5f17 !important; color: white }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-150 { background: #fb834d !important; color: white }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-75 { background: #fb9567 !important; color: white }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-15 { background: #ffae89 !important; color: black }
+	#tracy-debug td.nette-DbConnectionPanel-queryTime-5 { background: #fbccb7 !important; color: black }
 </style>
 
 <h1 title="<?= Helpers::escapeHtml($connection->getDsn()) ?>">Queries: <?php
@@ -29,7 +35,7 @@ use Tracy\Helpers;
 			[$connection, $sql, $params, $source, $time, $rows, $error, $command, $explain] = $query;
 		?>
 		<tr>
-		<td>
+		<td<?= ($durationColor = DbHelpers::queryTimeClass($time * 1000)) !== null ? ' class="' . Helpers::escapeHtml('nette-DbConnectionPanel-queryTime-' . $durationColor) . '"' : '' ?>>
 		<?php if ($error): ?>
 			<span title="<?= Helpers::escapeHtml($error) ?>">ERROR</span>
 		<?php elseif ($time !== null): echo sprintf('%0.3f', $time * 1000); endif ?>

--- a/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
+++ b/src/Bridges/DatabaseTracy/templates/ConnectionPanel.panel.phtml
@@ -29,7 +29,7 @@ use Tracy\Helpers;
 			[$connection, $sql, $params, $source, $time, $rows, $error, $command, $explain] = $query;
 		?>
 		<tr>
-		<td style="background:rgba(255, 95, 23, <?= log($time * 1000 + 1, 10) * DbHelpers::$queryPerformanceScale ?>)">
+		<td style="background:rgba(255, 95, 23, <?= sprintf('%0.3f', log($time * 1000 + 1, 10) * DbHelpers::$queryPerformanceScale) ?>)">
 		<?php if ($error): ?>
 			<span title="<?= Helpers::escapeHtml($error) ?>">ERROR</span>
 		<?php elseif ($time !== null): echo sprintf('%0.3f', $time * 1000); endif ?>

--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -35,6 +35,9 @@ class Helpers
 		'BYTEA|(TINY|MEDIUM|LONG|)BLOB|(LONG )?(VAR)?BINARY|IMAGE' => IStructure::FIELD_BINARY,
 	];
 
+	/** @var int[] (millisecond => percentage) */
+	public static $queryPerformanceScale = [10 => 10, 30 => 25, 50 => 50, 100 => 75, 200 => 90, 300 => 100];
+
 
 	/**
 	 * Displays complete result set as HTML table for debug purposes.
@@ -301,18 +304,20 @@ class Helpers
 	}
 
 
-	public static function queryTimeClass(float $time): ?string
+	public static function queryPerformanceOpacity(float $time): float
 	{
-		if ($time === null || $time < 5) {
-			return null;
+		if ($time < (array_keys(self::$queryPerformanceScale)[0] ?? 0)) {
+			return 0;
 		}
 
-		foreach ([500, 300, 150, 75, 15, 5] as $durationClass) {
-			if ($durationClass <= $time) {
-				return (string) $durationClass;
+		$matchedPercentage = 100;
+		foreach (self::$queryPerformanceScale as $timeItem => $percentage) {
+			if ($timeItem >= $time) {
+				$matchedPercentage = $percentage;
+				break;
 			}
 		}
 
-		return null;
+		return (($matchedPercentage + ($timeItem ?? 0)) / 2) / 100;
 	}
 }

--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -299,4 +299,20 @@ class Helpers
 		}
 		return implode(', ', $duplicates);
 	}
+
+
+	public static function queryTimeClass(float $time): ?string
+	{
+		if ($time === null || $time < 5) {
+			return null;
+		}
+
+		foreach ([500, 300, 150, 75, 15, 5] as $durationClass) {
+			if ($durationClass <= $time) {
+				return (string) $durationClass;
+			}
+		}
+
+		return null;
+	}
 }

--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -34,9 +34,10 @@ class Helpers
 		'(SMALL)?DATETIME(OFFSET)?\d*|TIME(STAMP.*)?' => IStructure::FIELD_DATETIME,
 		'BYTEA|(TINY|MEDIUM|LONG|)BLOB|(LONG )?(VAR)?BINARY|IMAGE' => IStructure::FIELD_BINARY,
 	];
+	
 
-	/** @var int[] (millisecond => percentage) */
-	public static $queryPerformanceScale = [10 => 10, 30 => 25, 50 => 50, 100 => 75, 200 => 90, 300 => 100];
+	/** @var float */
+	public static $queryPerformanceScale = 0.25;
 
 
 	/**
@@ -301,23 +302,5 @@ class Helpers
 			}
 		}
 		return implode(', ', $duplicates);
-	}
-
-
-	public static function queryPerformanceOpacity(float $time): float
-	{
-		if ($time < (array_keys(self::$queryPerformanceScale)[0] ?? 0)) {
-			return 0;
-		}
-
-		$matchedPercentage = 100;
-		foreach (self::$queryPerformanceScale as $timeItem => $percentage) {
-			if ($timeItem >= $time) {
-				$matchedPercentage = $percentage;
-				break;
-			}
-		}
-
-		return (($matchedPercentage + ($timeItem ?? 0)) / 2) / 100;
 	}
 }

--- a/src/Database/Helpers.php
+++ b/src/Database/Helpers.php
@@ -34,7 +34,7 @@ class Helpers
 		'(SMALL)?DATETIME(OFFSET)?\d*|TIME(STAMP.*)?' => IStructure::FIELD_DATETIME,
 		'BYTEA|(TINY|MEDIUM|LONG|)BLOB|(LONG )?(VAR)?BINARY|IMAGE' => IStructure::FIELD_BINARY,
 	];
-	
+
 
 	/** @var float */
 	public static $queryPerformanceScale = 0.25;


### PR DESCRIPTION
- new feature
- BC break? no

I would like the processing time to be displayed in color for each query. It is then easy to find slow questions and focus on them.

Some example:

![Snímek obrazovky 2020-06-01 v 17 50 19](https://user-images.githubusercontent.com/4738758/83427954-d90bbf80-a431-11ea-94d7-2d7ba843e053.png)

Thanks!