### PR TITLE
Extension: Added connection timeout

### DIFF
--- a/src/Bridges/DatabaseDI/DatabaseExtension.php
+++ b/src/Bridges/DatabaseDI/DatabaseExtension.php
@@ -38,6 +38,7 @@ class DatabaseExtension extends Nette\DI\CompilerExtension
 				'options' => Expect::array(),
 				'debugger' => Expect::bool(true),
 				'explain' => Expect::bool(true),
+				'connectionTimeout' => Expect::int()->min(0),
 				'reflection' => Expect::string(), // BC
 				'conventions' => Expect::string('discovered'), // Nette\Database\Conventions\DiscoveredConventions
 				'autowired' => Expect::bool(),
@@ -73,6 +74,10 @@ class DatabaseExtension extends Nette\DI\CompilerExtension
 				unset($config->options[$key]);
 				$config->options[constant($key)] = $value;
 			}
+		}
+
+		if ($config->connectionTimeout !== null) {
+			$config->options[\PDO::ATTR_TIMEOUT] = $config->connectionTimeout;
 		}
 
 		$connection = $builder->addDefinition($this->prefix("$name.connection"))


### PR DESCRIPTION
- new feature
- BC break? no

I think the connection timeout option can be defined separately because it is very important feature.

When I searched the Nette API for how to set the timeout, I didn't find any result. This option makes this setting easy to find and enable.
