### PR TITLE
MySqlDriver driver knows about subqueries now.

### DIFF
--- a/src/Database/Drivers/MySqlDriver.php
+++ b/src/Database/Drivers/MySqlDriver.php
@@ -204,6 +204,6 @@ class MySqlDriver implements Nette\Database\ISupplementalDriver
 		// - http://bugs.mysql.com/bug.php?id=31188
 		// - http://bugs.mysql.com/bug.php?id=35819
 		// and more.
-		return $item === self::SUPPORT_SELECT_UNGROUPED_COLUMNS || $item === self::SUPPORT_MULTI_COLUMN_AS_OR_COND;
+		return $item === self::SUPPORT_SELECT_UNGROUPED_COLUMNS || $item === self::SUPPORT_MULTI_COLUMN_AS_OR_COND || $item === self::SUPPORT_SUBSELECT;
 	}
 }


### PR DESCRIPTION
As MySQL/MariaDB clearly does support subqueries.

This enables proper building of queries like...
```php
$table('table_a')
  ->where(
    'table_a.column_one IN',
    $table('table_b')->select('value')
  )
```

... without executing the inner query first.

See https://dev.mysql.com/doc/refman/8.0/en/subqueries.html
and https://mariadb.com/kb/en/subqueries/

- bug fix / new feature? _Both, I think._
- BC break? _Who knows._

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
