### PR TITLE
PostgreSQL identity column

### DIFF
--- a/src/Database/Drivers/PgSqlDriver.php
+++ b/src/Database/Drivers/PgSqlDriver.php
@@ -135,9 +135,9 @@ class PgSqlDriver implements Nette\Database\Driver
 				CASE WHEN a.atttypmod = -1 THEN NULL ELSE a.atttypmod -4 END AS size,
 				NOT (a.attnotnull OR t.typtype = 'd' AND t.typnotnull) AS nullable,
 				pg_catalog.pg_get_expr(ad.adbin, 'pg_catalog.pg_attrdef'::regclass)::varchar AS default,
-				coalesce(co.contype = 'p' AND strpos(pg_catalog.pg_get_expr(ad.adbin, ad.adrelid), 'nextval') = 1, FALSE) AS autoincrement,
+				coalesce(co.contype = 'p' AND a.attidentity = ANY (ARRAY['a', 'd']) OR strpos(pg_catalog.pg_get_expr(ad.adbin, ad.adrelid), 'nextval') = 1, FALSE) AS autoincrement,
 				coalesce(co.contype = 'p', FALSE) AS primary,
-				substring(pg_catalog.pg_get_expr(ad.adbin, 'pg_catalog.pg_attrdef'::regclass) from 'nextval[(]''\"?([^''\"]+)') AS sequence
+				coalesce(pg_get_serial_sequence(c.relname, a.attname), substring(pg_catalog.pg_get_expr(ad.adbin, 'pg_catalog.pg_attrdef'::regclass) from 'nextval[(]''\"?([^''\"]+)')) AS sequence
 			FROM
 				pg_catalog.pg_attribute AS a
 				JOIN pg_catalog.pg_class AS c ON a.attrelid = c.oid


### PR DESCRIPTION
- bug fix
- BC break? no

Since PostgreSQL 10, identity columns are recommended instead of serial types as stated in the documentation (and serial types are even discouraged [here](https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_serial)).

Database Explorer doesn't recognise identity columns. Just adding `a.attidentity = ANY (ARRAY['a', 'd'])` does the trick.

A note about the last line in the change: 
With an auto increment column created in the correct way (by specifying SERIAL or IDENTITY) using `pg_get_serial_sequence()` is enough. However serial types can be created manually, but if the sequence is created without OWNED BY (e.g. Doctrine), that procedure returns null. I left the previous one to avoid breakage but since IDENTITY can't be created manually (and that procedure is the only way to get the sequence name in this case), in the future just `pg_get_serial_sequence()` is the way.

Tested on PostgreSQL 9.6 and 13.

