### PR TITLE
typo

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -291,7 +291,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 
 	/**
 	 * Adds where condition, more calls appends with AND.
-	 * @param  string|array<int|string, mixed>  $condition  possibly containing ?
+	 * @param  string|array  $condition  possibly containing ?
 	 */
 	public function where($condition, ...$params): static
 	{

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -291,7 +291,7 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 
 	/**
 	 * Adds where condition, more calls appends with AND.
-	 * @param  string|string[]  $condition  possibly containing ?
+	 * @param  string|array<int|string, mixed>  $condition  possibly containing ?
 	 */
 	public function where($condition, ...$params): static
 	{


### PR DESCRIPTION
Resolves https://github.com/nette/database/issues/254

- bug fix / new feature?  Fix for static analysis - issue #254 
- BC break? no
- doc PR: nette/docs#???  Will be updated if PR is accepted

As described in linked issue:

when using where condition as array:
```
$this->table('foo')->where(['is_deleted' => false, 'bar' => 'baz']);
```
PHPStan throws error:
```
Parameter #1 $condition of method Nette\Database\Table\Selection::where() expects array<string>|string, array<string, mixed> given.
```