### PR TITLE
Fixed aggregations when group by and having conditions are used

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -256,6 +256,19 @@ class SqlBuilder
 	}
 
 
+	public function importGroupConditions(self $builder): bool
+	{
+		if ($builder->having) {
+			$this->group = $builder->group;
+			$this->having = $builder->having;
+			$this->parameters['group'] = $builder->parameters['group'];
+			$this->parameters['having'] = $builder->parameters['having'];
+			return true;
+		}
+		return false;
+	}
+
+
 	/********************* SQL selectors ****************d*g**/
 
 

--- a/tests/Database/Explorer/Explorer.aggregation.phpt
+++ b/tests/Database/Explorer/Explorer.aggregation.phpt
@@ -41,3 +41,54 @@ test('', function () use ($explorer) {
 	Assert::count(2, $authors);
 	Assert::same(2, $authors->count('DISTINCT author.id'));  // SELECT COUNT(DISTINCT author.id) FROM `author` INNER JOIN `book` ON `author`.`id` = `book`.`author_id` WHERE (`book`.`translator_id` IS NOT NULL)
 });
+
+
+test('', function () use ($explorer) {
+	$authors = $explorer->table('book')->group('book.id')->having('COUNT(DISTINCT :book_tag.tag_id) < 2');  // SELECT `author`.* FROM `author` INNER JOIN `book` ON `author`.`id` = `book`.`author_id` WHERE (`book`.`translator_id` IS NOT NULL) GROUP BY `author`.`id`
+	Assert::count(2, $authors);
+	Assert::same(2, $authors->count('DISTINCT author.id'));  // SELECT COUNT(DISTINCT author.id) FROM `author` INNER JOIN `book` ON `author`.`id` = `book`.`author_id` WHERE (`book`.`translator_id` IS NOT NULL)
+});
+
+
+test('', function () use ($explorer) {
+	$bookTags = [];
+	foreach ($explorer->table('book') as $book) {
+		$book_tags = $book->related('book_tag');
+		$bookTags[$book->title] = $book_tags->count('DISTINCT tag.id');
+	}
+
+	Assert::same([
+		'1001 tipu a triku pro PHP' => 2,
+		'JUSH' => 1,
+		'Nette' => 1,
+		'Dibi' => 2,
+	], $bookTags);
+});
+
+
+test('', function () use ($explorer) {
+	$bookTags = [];
+	foreach ($explorer->table('book')->group('book.id, book.title')->having('COUNT(DISTINCT :book_tag.tag_id) < 2') as $book) {
+		$book_tags = $book->related('book_tag');
+		$bookTags[$book->title] = $book_tags->count('DISTINCT tag.id');
+	}
+
+	Assert::same([
+		'JUSH' => 1,
+		'Nette' => 1,
+	], $bookTags);
+});
+
+test('', function () use ($explorer) {
+	$bookTags = [];
+	foreach ($explorer->table('author') as $author) {
+		$books = $author->related('book');
+		$bookTags[$author->name] = $books->group('book.id')->having('COUNT(DISTINCT :book_tag.tag_id) < 2')->count('DISTINCT book.id');
+	}
+
+	Assert::same([
+		'Jakub Vrana' => 1,
+		'David Grudl' => 1,
+		'Geek' => 0,
+	], $bookTags);
+});


### PR DESCRIPTION
- bug fix
- BC break? Added optional parameter to method aggregate in Selection (signature change)

This fixes wrong results of aggregate functions applied on selection with group and having conditions. Previously aggregate of all rows even that not matching having conditions were returned.
