### PR TITLE
Allow partitioned tables to be returned by PgSqlDriver::getTables()

### DIFF
--- a/src/Database/Drivers/PgSqlDriver.php
+++ b/src/Database/Drivers/PgSqlDriver.php
@@ -101,7 +101,7 @@ class PgSqlDriver extends PdoDriver
 				pg_catalog.pg_class AS c
 				JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
 			WHERE
-				c.relkind IN ('r', 'v', 'm')
+				c.relkind IN ('p', 'r', 'v', 'm')
 				AND n.nspname = ANY (pg_catalog.current_schemas(FALSE))
 			ORDER BY
 				c.relname


### PR DESCRIPTION
- bug fix? yes
- BC break? no

<!--
Adding 'p' to IN(...) will allow Postgresql partitioned tables to be returned by getTables() method. Without 'p' only individual partitions are returned and not the main table.

See https://forum.nette.org/cs/34902-postgresql-a-partitioned-tabulka#p218219 for initial discussion.
See https://www.postgresql.org/docs/current/ddl-partitioning.html for info about partitioning in Postgresql.
-->
