### PR TITLE
tests: fix sqlsrv tests

### DIFF
--- a/tests/Database/Connection.transaction.phpt
+++ b/tests/Database/Connection.transaction.phpt
@@ -45,12 +45,8 @@ test('', function () use ($connection) {
 });
 
 
-if ($driverName === 'sqlsrv') {
-	Tester\Environment::skip("TODO: query('SELECT COUNT(*) FROM author')->fetchField() fails and I don't know why");
-}
-
 test('nested transaction() call fail', function () use ($connection) {
-	$base = (int) $connection->query('SELECT COUNT(*) FROM author')->fetchField();
+	$base = (int) $connection->query('SELECT COUNT(*) AS cnt FROM author')->fetchField();
 
 	Assert::exception(function () use ($connection) {
 		$connection->transaction(function (Connection $connection) {
@@ -69,12 +65,12 @@ test('nested transaction() call fail', function () use ($connection) {
 		});
 	}, Throwable::class, 'my exception');
 
-	Assert::same(0, $connection->query('SELECT COUNT(*) FROM author')->fetchField() - $base);
+	Assert::same(0, $connection->query('SELECT COUNT(*) AS cnt FROM author')->fetchField() - $base);
 });
 
 
 test('nested transaction() call success', function () use ($connection) {
-	$base = (int) $connection->query('SELECT COUNT(*) FROM author')->fetchField();
+	$base = (int) $connection->query('SELECT COUNT(*) AS cnt FROM author')->fetchField();
 
 	$connection->transaction(function (Connection $connection) {
 		$connection->query('INSERT INTO author', [
@@ -90,7 +86,7 @@ test('nested transaction() call success', function () use ($connection) {
 		});
 	});
 
-	Assert::same(2, $connection->query('SELECT COUNT(*) FROM author')->fetchField() - $base);
+	Assert::same(2, $connection->query('SELECT COUNT(*) AS cnt FROM author')->fetchField() - $base);
 });
 
 


### PR DESCRIPTION
I think it is because the SQLServer uses empty string as a name for `SELECT count(*)` column and empty name is prohibited so the result `Row` has no columns at all.

https://github.com/nette/database/blob/f534aa7261b5603618cd327b902fb07194f6554f/src/Database/ResultSet.php#L187-L192
