### PR TITLE
V2.4 fix sqlite driver get foreign keys method

### DIFF
--- a/src/Database/Drivers/SqliteDriver.php
+++ b/src/Database/Drivers/SqliteDriver.php
@@ -226,7 +226,7 @@ class SqliteDriver implements Nette\Database\ISupplementalDriver
 			$keys[$row['id']]['onDelete'] = $row['on_delete'];
 			$keys[$row['id']]['onUpdate'] = $row['on_update'];
 
-			if ($keys[$row['id']]['foreign'][0] == null) {
+			if (!isset($keys[$row['id']]['foreign'][0]) || $keys[$row['id']]['foreign'][0] == null) {
 				$keys[$row['id']]['foreign'] = null;
 			}
 		}


### PR DESCRIPTION
- bug 
- BC break: no

Hi, 

When I import data from files to sqlite3 database I got following error:

```
src/Database/Drivers/SqliteDriver.php:229
Trying to access array offset on value of type null

```
One thing is interesting. My colleague on OSX process import successfully without error.

```
nette/database v2.4.11
sqlite3 version: 3.27.2
OS: Linux

```

When I dump  **$keys[$row[‚id‘]]** before line 229 I get:

```
{
  "name": 0,
  "local": "key",
  "table": "cache",
  "foreign": null,
  "onDelete": "CASCADE",
  "onUpdate": "NO ACTION"
}

```

Code dont assume foreign is null.

https://forum.nette.org/cs/35537-nette-database-a-sqlite3-trying-to-access-array-offset-on-value-of-type-null#p221775
