### PR TITLE
Fix Invalid argument supplied for foreach() for empty aggregations

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -489,7 +489,11 @@ class Selection implements \Iterator, IRowContainer, \ArrayAccess, \Countable
 			return $this->explorer->query($query, ...$selection->getSqlBuilder()->getParameters())->fetch()->groupaggregate;
 		} else {
 			$selection->select($function);
-			foreach ($selection->fetch() as $val) {
+                        $values = $selection->fetch();
+                        if (!$values) {
+                            return null;
+                        }                        
+			foreach ($values as $val) {
 				return $val;
 			}
 		}


### PR DESCRIPTION
In case an aggregation returns 0 rows, the fetch returns null and foreach triggers a warning.

Use-case e.g.:
$selection->aggregation('MEDIAN(WEEKDAY(created)) OVER ()', 'MEDIAN')

- bug fix YES
- BC break? NO
