### PR TITLE
Fix multi-line insert return type

### DIFF
--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -791,7 +791,7 @@ class Selection implements \IteratorAggregate, \ArrayAccess, \Countable
 
 		$this->loadRefCache();
 
-		if ($data instanceof self || $this->primary === null) {
+		if ($data instanceof self || $this->primary === null || (is_array($data) && array_key_exists(0, $data))) {
 			unset($this->refCache['referencing'][$this->getGeneralCacheKey()][$this->getSpecificCacheKey()]);
 			return $return->getRowCount()
 				?? throw new Nette\InvalidStateException('Cannot determine the number of affected rows.');

--- a/src/Database/Table/Selection.php
+++ b/src/Database/Table/Selection.php
@@ -791,7 +791,7 @@ class Selection implements \IteratorAggregate, \ArrayAccess, \Countable
 
 		$this->loadRefCache();
 
-		if ($data instanceof self || $this->primary === null || (is_array($data) && array_key_exists(0, $data))) {
+		if ($data instanceof self || $this->primary === null || array_is_list($data)) {
 			unset($this->refCache['referencing'][$this->getGeneralCacheKey()][$this->getSpecificCacheKey()]);
 			return $return->getRowCount()
 				?? throw new Nette\InvalidStateException('Cannot determine the number of affected rows.');

--- a/tests/Database/Explorer/Selection.insert().multi.phpt
+++ b/tests/Database/Explorer/Selection.insert().multi.phpt
@@ -14,9 +14,9 @@ $explorer = connectToDB();
 Nette\Database\Helpers::loadFromFile($explorer, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
 
 
-test('', function () use ($explorer) {
+test('multi-insert on autoincrement table returns int row count', function () use ($explorer) {
 	Assert::same(3, $explorer->table('author')->count());
-	$explorer->table('author')->insert([
+	$result = $explorer->table('author')->insert([
 		[
 			'name' => 'Catelyn Stark',
 			'web' => 'http://example.com',
@@ -28,15 +28,21 @@ test('', function () use ($explorer) {
 			'born' => new DateTime('2021-11-11'),
 		],
 	]);  // INSERT INTO `author` (`name`, `web`, `born`) VALUES ('Catelyn Stark', 'http://example.com', '2011-11-11 00:00:00'), ('Sansa Stark', 'http://example.com', '2021-11-11 00:00:00')
+	Assert::type('int', $result);
+	Assert::same(2, $result);
 	Assert::same(5, $explorer->table('author')->count());
+});
 
+test('multi-insert on composite primary key table returns int row count', function () use ($explorer) {
 	$explorer->table('book_tag')->where('book_id', 1)->delete();  // DELETE FROM `book_tag` WHERE (`book_id` = ?)
 
 	Assert::same(4, $explorer->table('book_tag')->count());
-	$explorer->table('book')->get(1)->related('book_tag')->insert([  // SELECT * FROM `book` WHERE (`id` = ?)
+	$result = $explorer->table('book')->get(1)->related('book_tag')->insert([  // SELECT * FROM `book` WHERE (`id` = ?)
 		['tag_id' => 21],
 		['tag_id' => 22],
 		['tag_id' => 23],
 	]);  // INSERT INTO `book_tag` (`tag_id`, `book_id`) VALUES (21, 1), (22, 1), (23, 1)
+	Assert::type('int', $result);
+	Assert::same(3, $result);
 	Assert::same(7, $explorer->table('book_tag')->count());
 });

--- a/tests/Database/Explorer/Selection.insert().multi.phpt
+++ b/tests/Database/Explorer/Selection.insert().multi.phpt
@@ -14,7 +14,7 @@ $explorer = connectToDB();
 Nette\Database\Helpers::loadFromFile($explorer, __DIR__ . "/../files/{$driverName}-nette_test1.sql");
 
 
-test('multi-insert on autoincrement table returns int row count', function () use ($explorer) {
+test('', function () use ($explorer) {
 	Assert::same(3, $explorer->table('author')->count());
 	$result = $explorer->table('author')->insert([
 		[
@@ -31,9 +31,7 @@ test('multi-insert on autoincrement table returns int row count', function () us
 	Assert::type('int', $result);
 	Assert::same(2, $result);
 	Assert::same(5, $explorer->table('author')->count());
-});
 
-test('multi-insert on composite primary key table returns int row count', function () use ($explorer) {
 	$explorer->table('book_tag')->where('book_id', 1)->delete();  // DELETE FROM `book_tag` WHERE (`book_id` = ?)
 
 	Assert::same(4, $explorer->table('book_tag')->count());


### PR DESCRIPTION
- bug fix
- BC break yes and no - **yes** since the current algorithm returns ActiveRow instead of int. **no** since this change actually aligns the algorithm with the documented behaviour
- forum thread: https://forum.nette.org/cs/36954-nette-database-v3-2-9-phpdoc-selection-insert-nepokryva-dokumentovany-bulk-insert#p229075

Multi-line inserting wasnt returning numeric number of affected rows but ActiveRow instead (with first inserted record).

This fix checks if the `$data` inserted is actually a two-dimensional array and if so, returns number of affected rows instead of the ActiveRow.

Tests were added as well since this path was not guarded