### PR TITLE
Fix joined conditions in selection delete

### DIFF
--- a/src/Database/Table/SqlBuilder.php
+++ b/src/Database/Table/SqlBuilder.php
@@ -113,12 +113,41 @@ class SqlBuilder
 
 	public function buildDeleteQuery(): string
 	{
-		$query = "DELETE FROM {$this->delimitedTable}" . $this->tryDelimit($this->buildConditions());
+		$queryCondition = $this->buildConditions();
+		$joins = [];
+		$finalJoinConditions = $this->parseJoinConditions($joins, $this->buildJoinConditions());
+		$this->parseJoins($joins, $queryCondition);
+
+		if ($joins) {
+			$primary = $this->conventions->getPrimary($this->tableName);
+			if (!$primary) {
+				throw new Nette\NotSupportedException("Table '{$this->tableName}' has no primary key.");
+			}
+
+			$primary = (array) $primary;
+			$queryPrimary = $primary;
+			foreach ($queryPrimary as &$column) {
+				$column = "{$this->delimitedTable}.{$column}";
+			}
+
+			$select = 'SELECT ' . implode(', ', $queryPrimary)
+				. " FROM {$this->delimitedTable}"
+				. $this->buildQueryJoins($joins, $finalJoinConditions)
+				. $queryCondition;
+
+			$primary = count($primary) === 1
+				? $primary[0]
+				: '(' . implode(', ', $primary) . ')';
+			$query = "DELETE FROM {$this->delimitedTable} WHERE $primary IN (SELECT $primary FROM ($select) nette_delete)";
+		} else {
+			$query = "DELETE FROM {$this->delimitedTable}" . $queryCondition;
+		}
+
 		if ($this->limit !== null || $this->offset) {
 			$query = $this->engine->applyLimit($query, $this->limit, $this->offset);
 		}
 
-		return $query;
+		return $this->tryDelimit($query);
 	}
 
 

--- a/tests/Database/Explorer/Selection.delete().phpt
+++ b/tests/Database/Explorer/Selection.delete().phpt
@@ -22,6 +22,13 @@ test('delete records by condition in book_tag', function () use ($explorer) {
 });
 
 
+test('delete records by condition on referenced table', function () use ($explorer) {
+	$explorer->table('book')->where('author.name', 'Jakub Vrana')->delete();
+
+	Assert::same(0, $explorer->table('book')->where('author.name', 'Jakub Vrana')->count());
+});
+
+
 test('delete related book_tag_alt and cascade book deletion', function () use ($explorer) {
 	$book = $explorer->table('book')->get(3);  // SELECT * FROM `book` WHERE (`id` = ?)
 	$book->related('book_tag_alt')->where('tag_id', 21)->delete();  // DELETE FROM `book_tag_alt` WHERE (`book_id` = ?) AND (`tag_id` = ?)


### PR DESCRIPTION
Fixes #255.

This updates selection deletes with relationship conditions so the generated delete uses the joined condition in a derived primary-key select instead of referencing a joined-table column from the outer delete.

Validation:
- `docker run --rm -v "$PWD":/app -w /app php:8.4-cli sh -lc 'php -l src/Database/Table/SqlBuilder.php && php -l tests/Database/Explorer/Selection.delete\(\).phpt'`
- Focused SQLite smoke for deleting `book` rows filtered by `author.name`.
